### PR TITLE
Add user agent to requests

### DIFF
--- a/app/src/androidTest/java/com/okta/oidc/example/WireMockTest.java
+++ b/app/src/androidTest/java/com/okta/oidc/example/WireMockTest.java
@@ -16,6 +16,19 @@ package com.okta.oidc.example;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.UiSelector;
+import androidx.test.uiautomator.Until;
+
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.okta.oidc.AuthenticateClient;
@@ -46,19 +59,6 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
-import androidx.annotation.NonNull;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.LargeTest;
-import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.rule.GrantPermissionRule;
-import androidx.test.uiautomator.By;
-import androidx.test.uiautomator.UiDevice;
-import androidx.test.uiautomator.UiObject;
-import androidx.test.uiautomator.UiObjectNotFoundException;
-import androidx.test.uiautomator.UiSelector;
-import androidx.test.uiautomator.Until;
-
 import static android.Manifest.permission.INTERNET;
 import static android.Manifest.permission.READ_EXTERNAL_STORAGE;
 import static androidx.test.espresso.Espresso.onView;
@@ -69,12 +69,18 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.okta.oidc.example.Utils.getAsset;
 import static com.okta.oidc.example.Utils.getNow;
 import static com.okta.oidc.example.Utils.getTomorrow;
 import static com.okta.oidc.example.WireMockStubs.mockConfigurationRequest;
 import static com.okta.oidc.example.WireMockStubs.mockTokenRequest;
 import static com.okta.oidc.example.WireMockStubs.mockWebAuthorizeRequest;
+import static com.okta.oidc.net.HttpConnection.USER_AGENT_HEADER;
+import static com.okta.oidc.net.HttpConnection.X_OKTA_USER_AGENT;
 import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.core.StringContains.containsString;
@@ -265,5 +271,8 @@ public class WireMockTest {
         onView(withId(R.id.get_profile)).check(matches(isDisplayed()));
         onView(withId(R.id.status))
                 .check(matches(withText(containsString("authentication authorized"))));
+
+        verify(getRequestedFor(urlMatching("/authorize.*"))
+                .withHeader(X_OKTA_USER_AGENT, equalTo(USER_AGENT_HEADER)));
     }
 }

--- a/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
+++ b/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
@@ -21,7 +21,17 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
+import android.provider.Browser;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.browser.customtabs.CustomTabsClient;
+import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabsService;
+import androidx.browser.customtabs.CustomTabsServiceConnection;
+import androidx.browser.customtabs.CustomTabsSession;
 
 import com.okta.oidc.util.AuthorizationException;
 
@@ -32,14 +42,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
-import androidx.browser.customtabs.CustomTabsClient;
-import androidx.browser.customtabs.CustomTabsIntent;
-import androidx.browser.customtabs.CustomTabsService;
-import androidx.browser.customtabs.CustomTabsServiceConnection;
-import androidx.browser.customtabs.CustomTabsSession;
+import static com.okta.oidc.net.HttpConnection.USER_AGENT_HEADER;
+import static com.okta.oidc.net.HttpConnection.X_OKTA_USER_AGENT;
 
 public class OktaAuthenticationActivity extends Activity {
     private static final String TAG = OktaAuthenticationActivity.class.getSimpleName();
@@ -159,6 +163,9 @@ public class OktaAuthenticationActivity extends Activity {
         tabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
         tabsIntent.intent.setPackage(packageName);
         tabsIntent.intent.setData(mAuthUri);
+        Bundle headers = new Bundle();
+        headers.putString(X_OKTA_USER_AGENT, USER_AGENT_HEADER);
+        tabsIntent.intent.putExtra(Browser.EXTRA_HEADERS, headers);
         return tabsIntent.intent;
     }
 

--- a/library/src/main/java/com/okta/oidc/net/HttpConnection.java
+++ b/library/src/main/java/com/okta/oidc/net/HttpConnection.java
@@ -16,6 +16,10 @@ package com.okta.oidc.net;
 
 import android.os.Build;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
+import androidx.annotation.VisibleForTesting;
+
 import com.okta.oidc.BuildConfig;
 import com.okta.oidc.net.request.TLSSocketFactory;
 import com.okta.oidc.util.Preconditions;
@@ -36,10 +40,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.HttpsURLConnection;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.RestrictTo;
-import androidx.annotation.VisibleForTesting;
-
 import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 
 @RestrictTo(LIBRARY_GROUP)
@@ -51,8 +51,9 @@ public class HttpConnection {
     public static final String JSON_CONTENT_TYPE = String.format("application/json; charset=%s",
             DEFAULT_ENCODING);
     public static final String USER_AGENT = "User-Agent";
-    public static final String USER_AGENT_HEADER = "Android/" + Build.VERSION.SDK_INT + " " +
-            BuildConfig.APPLICATION_ID + "/" + BuildConfig.VERSION_NAME;
+    public static final String X_OKTA_USER_AGENT = "X-Okta-User-Agent-Extended";
+    public static final String USER_AGENT_HEADER = "okta-oidc-android/" + Build.VERSION.SDK_INT +
+            " " + BuildConfig.APPLICATION_ID + "/" + BuildConfig.VERSION_NAME;
 
     public enum RequestMethod {
         GET, POST
@@ -81,11 +82,7 @@ public class HttpConnection {
         conn.setReadTimeout(mReadTimeOutMs);
         conn.setInstanceFollowRedirects(false);
         Map<String, List<String>> properties = conn.getRequestProperties();
-        if (properties.get(USER_AGENT) == null &&
-                (mRequestProperties == null || !mRequestProperties.containsKey(USER_AGENT))) {
-            conn.setRequestProperty(USER_AGENT, USER_AGENT_HEADER);
-        }
-        if (properties.get(USER_AGENT) == null &&
+        if (properties.get(CONTENT_TYPE) == null &&
                 (mRequestProperties == null || !mRequestProperties.containsKey(CONTENT_TYPE))) {
             conn.setRequestProperty(CONTENT_TYPE, DEFAULT_CONTENT_TYPE);
         }
@@ -94,6 +91,7 @@ public class HttpConnection {
                 conn.setRequestProperty(property, mRequestProperties.get(property));
             }
         }
+        conn.setRequestProperty(USER_AGENT, USER_AGENT_HEADER);
         if (mRequestMethod == RequestMethod.GET) {
             conn.setRequestMethod("GET");
             conn.setDoInput(true);

--- a/library/src/main/java/com/okta/oidc/net/request/web/AuthorizeRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/web/AuthorizeRequest.java
@@ -17,6 +17,10 @@ package com.okta.oidc.net.request.web;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+
 import com.google.gson.Gson;
 import com.okta.oidc.AuthenticationPayload;
 import com.okta.oidc.OIDCAccount;
@@ -30,10 +34,6 @@ import com.okta.oidc.util.CodeVerifierUtil;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.RestrictTo;
 
 //https://developer.okta.com/docs/api/resources/oidc#authorize
 @RestrictTo(RestrictTo.Scope.LIBRARY)

--- a/library/src/main/java/com/okta/oidc/net/request/web/LogoutRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/web/LogoutRequest.java
@@ -17,14 +17,14 @@ package com.okta.oidc.net.request.web;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.Gson;
 import com.okta.oidc.OIDCAccount;
 import com.okta.oidc.net.request.ProviderConfiguration;
 import com.okta.oidc.net.response.TokenResponse;
 import com.okta.oidc.util.CodeVerifierUtil;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 //https://developer.okta.com/docs/api/resources/oidc#logout
 public class LogoutRequest extends WebRequest {

--- a/library/src/test/java/com/okta/oidc/net/HttpConnectionTest.java
+++ b/library/src/test/java/com/okta/oidc/net/HttpConnectionTest.java
@@ -20,7 +20,6 @@ import com.okta.oidc.util.DateUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -40,11 +39,13 @@ import okhttp3.mockwebserver.RecordedRequest;
 import okhttp3.mockwebserver.SocketPolicy;
 
 import static com.okta.oidc.net.HttpConnection.USER_AGENT;
+import static com.okta.oidc.net.HttpConnection.USER_AGENT_HEADER;
 import static com.okta.oidc.util.TestValues.CLIENT_ID;
 import static com.okta.oidc.util.TestValues.CUSTOM_USER_AGENT;
 import static com.okta.oidc.util.TestValues.REDIRECT_URI;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 27)
@@ -72,7 +73,8 @@ public class HttpConnectionTest {
         int code = urlConnection.getResponseCode();
         RecordedRequest recordedRequest = mServer.takeRequest();
         assertEquals(code, HTTP_OK);
-        assertEquals(recordedRequest.getHeader(USER_AGENT), CUSTOM_USER_AGENT);
+        //HttpConnection overrides any custom user-agents
+        assertEquals(recordedRequest.getHeader(USER_AGENT), USER_AGENT_HEADER);
     }
 
     @Test
@@ -91,7 +93,8 @@ public class HttpConnectionTest {
         int code = urlConnection.getResponseCode();
         RecordedRequest recordedRequest = mServer.takeRequest();
         assertEquals(code, HTTP_OK);
-        assertEquals(recordedRequest.getHeader(USER_AGENT), CUSTOM_USER_AGENT);
+        //HttpConnection overrides custom user agent.
+        assertEquals(recordedRequest.getHeader(USER_AGENT), USER_AGENT_HEADER);
         assertEquals(recordedRequest.getHeader("PROP"), "PROP");
         assertEquals(recordedRequest.getHeader("PROP1"), "PROP1");
     }

--- a/library/src/test/java/com/okta/oidc/net/request/web/AuthorizeRequestTest.java
+++ b/library/src/test/java/com/okta/oidc/net/request/web/AuthorizeRequestTest.java
@@ -42,7 +42,7 @@ import static com.okta.oidc.util.TestValues.EXPIRES_IN;
 import static com.okta.oidc.util.TestValues.LOGIN_HINT;
 import static com.okta.oidc.util.TestValues.PROMPT;
 import static com.okta.oidc.util.TestValues.SCOPES;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 27)

--- a/library/src/test/java/com/okta/oidc/net/request/web/LogoutRequestTest.java
+++ b/library/src/test/java/com/okta/oidc/net/request/web/LogoutRequestTest.java
@@ -34,7 +34,6 @@ import static com.okta.oidc.util.JsonStrings.TOKEN_RESPONSE;
 import static com.okta.oidc.util.TestValues.CUSTOM_STATE;
 import static com.okta.oidc.util.TestValues.CUSTOM_URL;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 27)
@@ -124,5 +123,4 @@ public class LogoutRequestTest {
         LogoutRequest request = new LogoutRequest(parameters);
         assertEquals(request.persist(), json);
     }
-
 }


### PR DESCRIPTION
User agent will be something like:

okta-oidc-android/28 com.okta.oidc/1.0.0
{sdk}/{android platform} {SDK package identifier}/{version}

WireMockTest to verify browser header contains X-Okta-User-Agent-Extended.
Other requests are verified using MockWebServer unit tests.