### PR TITLE
Simplify gradle commandLine. Fix ci-build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,55 +79,33 @@ dependencies {
     }
 }
 
+def adb = System.getenv("ANDROID_HOME") + "/platform-tools/adb"
 task prepareDeviceForUITesting(type: Exec) {
     //disable animations for testing
-    def adb = System.getenv("ANDROID_HOME") + "/platform-tools/adb"
-    def anim_window = [adb, 'shell', 'settings', 'put', 'global', 'window_animation_scale', '0']
-    def anim_transition = [adb, 'shell', 'settings', 'put', 'global', 'transition_animation_scale', '0']
-    def animator = [adb, 'shell', 'settings', 'put', 'global', 'animator_duration_scale', '0']
-
-    // Enable Don't keep activities
-    def dont_keep_activities = [adb, 'shell', 'settings', 'put', 'global', 'always_finish_activities', '1']
-
+    commandLine adb, 'shell', 'settings', 'put', 'global', 'window_animation_scale', '0'
+    commandLine adb, 'shell', 'settings', 'put', 'global', 'transition_animation_scale', '0'
+    commandLine adb, 'shell', 'settings', 'put', 'global', 'animator_duration_scale', '0'
+    //always finish activity
+    commandLine adb, 'shell', 'settings', 'put', 'global', 'always_finish_activities', '1'
     // push keystore file to sdcard
-    def keystore_file = [adb, 'push', 'src/androidTest/assets/mock.keystore.bks', '/sdcard/Download/']
-
-    commandLine anim_window
-    commandLine anim_transition
-    commandLine animator
-    commandLine dont_keep_activities
-    commandLine keystore_file
+    commandLine adb, 'push', 'src/androidTest/assets/mock.keystore.bks', '/sdcard/Download/'
 }
 
 task clearData(type: Exec) {
-    def adb = System.getenv("ANDROID_HOME") + "/platform-tools/adb"
-    def clearAppData = [adb, 'shell', 'pm', 'clear', 'com.okta.oidc.example']
-    def clearTestAppData = [adb, 'shell', 'pm', 'clear', 'com.okta.oidc.example.test']
-    def clearChromeData = [adb, 'shell', 'pm', 'clear', 'com.android.chrome']
-
-    commandLine clearAppData
-    commandLine clearTestAppData
-    commandLine clearChromeData
+    commandLine adb, 'shell', 'pm', 'clear', 'com.okta.oidc.example'
+    commandLine adb, 'shell', 'pm', 'clear', 'com.okta.oidc.example.test'
+    commandLine adb, 'shell', 'pm', 'clear', 'com.android.chrome'
 }
 
 task restoreDeviceSettings(type: Exec) {
-    //restore animation on test device
-    def adb = System.getenv("ANDROID_HOME") + "/platform-tools/adb"
-    def anim_window = [adb, 'shell', 'settings', 'put', 'global', 'window_animation_scale', '1']
-    def anim_transition = [adb, 'shell', 'settings', 'put', 'global', 'transition_animation_scale', '1']
-    def animator = [adb, 'shell', 'settings', 'put', 'global', 'animator_duration_scale', '1']
-
-    // Disable Don't keep activities
-    def dont_keep_activities = [adb, 'shell', 'settings', 'put', 'global', 'always_finish_activities', '0']
-
-    // remove keystore file from sdcard
-    def keystore_file = [adb, 'shell', 'rm', '/sdcard/Download/mock.keystore.bks']
-
-    commandLine anim_window
-    commandLine anim_transition
-    commandLine animator
-    commandLine dont_keep_activities
-    commandLine keystore_file
+    //enable animations for testing
+    commandLine adb, 'shell', 'settings', 'put', 'global', 'window_animation_scale', '1'
+    commandLine adb, 'shell', 'settings', 'put', 'global', 'transition_animation_scale', '1'
+    commandLine adb, 'shell', 'settings', 'put', 'global', 'animator_duration_scale', '1'
+    //disable finish activity
+    commandLine adb, 'shell', 'settings', 'put', 'global', 'always_finish_activities', '0'
+    // remove keystore file to sdcard
+    commandLine adb, 'shell', 'rm', '/sdcard/Download/mock.keystore.bks'
 }
 
 dependencyCheck {

--- a/ci-build/espresso-tests.sh
+++ b/ci-build/espresso-tests.sh
@@ -120,6 +120,27 @@ pushd ${OKTA_HOME}/${REPO}/ci-build > /dev/null
 
 pushd ${OKTA_HOME}/${REPO} > /dev/null
 
+function create_localproperties() {
+    echo "================================================"
+    echo "Create local.properties file"
+    echo "================================================"
+    localprop="local.properties"
+    if [[ -f ${localprop} ]] ; then
+        rm ${localprop}
+    fi
+    echo "test.username=\"$username\"" >> ${localprop}
+    echo "test.password=\"$password\"" >> ${localprop}
+    echo "ndk.dir=$ANDROID_HOME/ndk-bundle" >> ${localprop}
+    echo "sdk.dir=$ANDROID_HOME" >> ${localprop}
+}
+if ! create_localproperties; then
+    echo "================================================"
+    echo "Failed to create local.properties file"
+    echo "================================================"
+    exit 1
+fi
+
+
 function check_device_connection() {
     echo "================================"
     echo "check for adb-connected device"
@@ -172,14 +193,6 @@ function gradlew_prepare_device() {
     echo "============="
     echo "gradlew_prepareDeviceForUITesting"
     echo "============="
-    localprop="local.properties"
-    if [[ -f ${localprop} ]] ; then
-        rm ${localprop}
-    fi
-    echo "test.username=\"$username\"" >> ${localprop}
-    echo "test.password=\"$password\"" >> ${localprop}
-    echo "ndk.dir=$ANDROID_HOME/ndk-bundle" >> ${localprop}
-    echo "sdk.dir=$ANDROID_HOME" >> ${localprop}
 
     ./gradlew prepareDeviceForUITesting
 }


### PR DESCRIPTION
ci-build script was failing due to missing
local.properties file. Gradle doesn't like that
so generate one at the start of script