### PR TITLE
Add check for hardware backed keystore

### DIFF
--- a/app/src/androidTest/java/com/okta/oidc/example/EncryptionTest.java
+++ b/app/src/androidTest/java/com/okta/oidc/example/EncryptionTest.java
@@ -1,0 +1,104 @@
+package com.okta.oidc.example;
+
+import android.content.Context;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.ActivityTestRule;
+
+import com.okta.oidc.storage.security.EncryptionManager;
+import com.okta.oidc.storage.security.SimpleEncryptionManager;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyStoreException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.UnrecoverableEntryException;
+import java.security.cert.CertificateException;
+
+import javax.crypto.NoSuchPaddingException;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class EncryptionTest {
+    private EncryptionManager mEncryptionManager;
+    private String mConfiguration;
+    @Rule
+    public ActivityTestRule<SampleActivity> activityRule = new ActivityTestRule<>(SampleActivity.class);
+
+    @Before
+    public void setUp() throws IOException, CertificateException, NoSuchAlgorithmException,
+            InvalidKeyException, UnrecoverableEntryException, InvalidAlgorithmParameterException,
+            NoSuchPaddingException, NoSuchProviderException, KeyStoreException {
+        mEncryptionManager = new SimpleEncryptionManager(activityRule.getActivity());
+        Context context = InstrumentationRegistry.getInstrumentation().getContext();
+        mConfiguration = Utils.getAsset(context, "configuration.json");
+    }
+
+    @Test
+    public void checkHardwareKeystore() {
+        boolean hardwareBacked = mEncryptionManager.isHardwareBackedKeyStore();
+        if (Utils.isEmulator()) {
+            assertFalse(hardwareBacked);
+        } else {
+            assertTrue(hardwareBacked);
+        }
+    }
+
+    @Test
+    public void encryptData() throws GeneralSecurityException, IOException,
+            IllegalArgumentException {
+        String encrypted = mEncryptionManager.encrypt(mConfiguration);
+        //check if the encrypted data is base64 encoded.
+        android.util.Base64.decode(encrypted, android.util.Base64.NO_WRAP);
+        assertNotNull(encrypted);
+        assertNotNull(mConfiguration);
+        assertNotEquals(encrypted, mConfiguration);
+    }
+
+    @Test
+    public void decryptData() throws GeneralSecurityException, IOException,
+            IllegalArgumentException {
+        String encrypted = mEncryptionManager.encrypt(mConfiguration);
+        String decryptData = mEncryptionManager.decrypt(encrypted);
+        assertNotNull(decryptData);
+        assertNotNull(mConfiguration);
+        assertEquals(decryptData, mConfiguration);
+    }
+
+    @Test
+    public void getHash() throws NoSuchAlgorithmException, UnsupportedEncodingException {
+        String testValue = "TestValue";
+        String hashedValue = mEncryptionManager.getHashed(testValue);
+        assertNotEquals(hashedValue, testValue);
+
+        final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] result = digest.digest(testValue.getBytes("UTF-8"));
+        StringBuilder sb = new StringBuilder();
+        for (byte b : result) {
+            sb.append(String.format("%02X", b));
+        }
+        String sameHash = sb.toString();
+        assertNotNull(sameHash);
+        assertNotNull(hashedValue);
+        assertEquals(sameHash, hashedValue);
+    }
+
+}

--- a/app/src/androidTest/java/com/okta/oidc/example/Utils.java
+++ b/app/src/androidTest/java/com/okta/oidc/example/Utils.java
@@ -15,6 +15,7 @@
 package com.okta.oidc.example;
 
 import android.content.Context;
+import android.os.Build;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -93,5 +94,16 @@ final class Utils {
         c.setTime(getNow());
         c.add(Calendar.DATE, 2);
         return c.getTime();
+    }
+
+    public static boolean isEmulator() {
+        return Build.FINGERPRINT.startsWith("generic")
+                || Build.FINGERPRINT.startsWith("unknown")
+                || Build.MODEL.contains("google_sdk")
+                || Build.MODEL.contains("Emulator")
+                || Build.MODEL.contains("Android SDK built for x86")
+                || Build.MANUFACTURER.contains("Google")
+                || Build.PRODUCT.contains("sdk_gphone")
+                || Build.DEVICE.contains("generic");
     }
 }

--- a/app/src/main/java/com/okta/oidc/example/SampleActivity.java
+++ b/app/src/main/java/com/okta/oidc/example/SampleActivity.java
@@ -118,6 +118,14 @@ public class SampleActivity extends AppCompatActivity implements SignInDialog.Si
     AuthenticationPayload mPayload;
 
     /**
+     * The payload to send for authorization.
+     */
+    @VisibleForTesting
+    SimpleOktaStorage mStorageOidc;
+    @VisibleForTesting
+    SimpleOktaStorage mStorageOAuth2;
+
+    /**
      * The Authentication API client.
      */
     protected AuthenticationClient mAuthenticationClient;
@@ -147,6 +155,8 @@ public class SampleActivity extends AppCompatActivity implements SignInDialog.Si
         mIntrospectId = findViewById(R.id.introspect_id);
         mSwitch = findViewById(R.id.switch1);
 
+        mStorageOAuth2 = new SimpleOktaStorage(this, "OAUTH2");
+        mStorageOidc = new SimpleOktaStorage(this);
         boolean checked = getSharedPreferences(SampleActivity.class.getName(), MODE_PRIVATE)
                 .getBoolean("switch", true);
 
@@ -364,7 +374,7 @@ public class SampleActivity extends AppCompatActivity implements SignInDialog.Si
         mWebOAuth2 = new Okta.WebAuthBuilder()
                 .withConfig(mOAuth2Config)
                 .withContext(getApplicationContext())
-                .withStorage(new SimpleOktaStorage(this, "OAUTH2"))
+                .withStorage(mStorageOAuth2)
                 .withCallbackExecutor(null)
                 .withTabColor(0)
                 .supportedBrowsers(FIRE_FOX)
@@ -375,7 +385,7 @@ public class SampleActivity extends AppCompatActivity implements SignInDialog.Si
         mWebAuth = new Okta.WebAuthBuilder()
                 .withConfig(mOidcConfig)
                 .withContext(getApplicationContext())
-                .withStorage(new SimpleOktaStorage(this))
+                .withStorage(mStorageOidc)
                 .withCallbackExecutor(null)
                 .withTabColor(0)
                 .supportedBrowsers(FIRE_FOX)
@@ -485,7 +495,7 @@ public class SampleActivity extends AppCompatActivity implements SignInDialog.Si
 
     private void showSignedOutMode() {
         mSignInBrowser.setVisibility(View.VISIBLE);
-        if (mAuthenticationClient != null) {//authentication client requires api 24
+        if (mAuthenticationClient != null) {
             mSignInNative.setVisibility(View.VISIBLE);
         } else {
             mSignInNative.setVisibility(View.GONE);

--- a/library/src/main/java/com/okta/oidc/storage/OktaStorage.java
+++ b/library/src/main/java/com/okta/oidc/storage/OktaStorage.java
@@ -47,4 +47,12 @@ public interface OktaStorage {
      * @param key the key
      */
     void delete(@NonNull String key);
+
+    /**
+     * Check to see if hardware backed keystore is required for storing data. If true and the device
+     * doesn't have hardware support then no data will be persisted on the device.
+     *
+     * @return true if hardware backed keystore is required.
+     */
+    boolean requireHardwareBackedKeyStore();
 }

--- a/library/src/main/java/com/okta/oidc/storage/SimpleOktaStorage.java
+++ b/library/src/main/java/com/okta/oidc/storage/SimpleOktaStorage.java
@@ -21,6 +21,7 @@ import android.content.SharedPreferences;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import static android.content.Context.MODE_PRIVATE;
 
@@ -31,7 +32,10 @@ import static android.content.Context.MODE_PRIVATE;
  */
 @SuppressLint("ApplySharedPref")
 public class SimpleOktaStorage implements OktaStorage {
-    private SharedPreferences prefs;
+    @VisibleForTesting
+    protected SharedPreferences prefs;
+    @VisibleForTesting
+    public boolean requireHardwareKeyStore = true;
 
     /**
      * Instantiates a new instance.
@@ -69,5 +73,10 @@ public class SimpleOktaStorage implements OktaStorage {
     @Override
     public void delete(@NonNull String key) {
         prefs.edit().remove(key).commit();
+    }
+
+    @Override
+    public boolean requireHardwareBackedKeyStore() {
+        return requireHardwareKeyStore;
     }
 }

--- a/library/src/main/java/com/okta/oidc/storage/security/EncryptionManager.java
+++ b/library/src/main/java/com/okta/oidc/storage/security/EncryptionManager.java
@@ -32,16 +32,17 @@ public interface EncryptionManager {
      * @param value value as a string.
      * @return encrypted value.
      * @throws GeneralSecurityException if has problems with algorithms used.
-     * @throws IOException if failed to open input stream
+     * @throws IOException              if failed to open input stream
      */
     String encrypt(String value) throws GeneralSecurityException, IOException;
 
     /**
      * decrypts encrypted value.
+     *
      * @param value encrypted value as a string.
      * @return decrypted value.
-     * @throws GeneralSecurityException  if has problems with algorithms used.
-     * @throws IOException if failed to open input stream
+     * @throws GeneralSecurityException if has problems with algorithms used.
+     * @throws IOException              if failed to open input stream
      */
     String decrypt(String value) throws GeneralSecurityException, IOException;
 
@@ -50,9 +51,15 @@ public interface EncryptionManager {
      *
      * @param value string to generate hash from.
      * @return hashed value.
-     * @throws NoSuchAlgorithmException if device does not support SHA-2.
+     * @throws NoSuchAlgorithmException     if device does not support SHA-2.
      * @throws UnsupportedEncodingException if wrong encoding used.
      */
     String getHashed(String value) throws NoSuchAlgorithmException, UnsupportedEncodingException;
 
+    /**
+     * if the key store is backed by hardware.
+     *
+     * @return true if hardware backed keystore is supported
+     */
+    boolean isHardwareBackedKeyStore();
 }

--- a/library/src/main/java/com/okta/oidc/storage/security/SimpleEncryptionManager.java
+++ b/library/src/main/java/com/okta/oidc/storage/security/SimpleEncryptionManager.java
@@ -15,14 +15,19 @@
 
 package com.okta.oidc.storage.security;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
+import android.security.KeyChain;
 import android.security.KeyPairGeneratorSpec;
 import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyInfo;
 import android.security.keystore.KeyProperties;
 import android.util.Base64;
+import android.util.Log;
+
 import androidx.annotation.Nullable;
 
 import java.io.ByteArrayInputStream;
@@ -33,6 +38,7 @@ import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
+import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -44,6 +50,7 @@ import java.security.UnrecoverableEntryException;
 import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
 import java.util.Calendar;
 
@@ -56,6 +63,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
@@ -65,6 +73,7 @@ import javax.security.auth.x500.X500Principal;
  * TODO .
  */
 public class SimpleEncryptionManager implements EncryptionManager {
+    private static final String TAG = SimpleEncryptionManager.class.getSimpleName();
     private static final int RSA_BIT_LENGTH = 2048;
     private static final int AES_BIT_LENGTH = 256;
     private static final int MAC_BIT_LENGTH = 256;
@@ -140,18 +149,18 @@ public class SimpleEncryptionManager implements EncryptionManager {
      * builds configured instance of SimpleEncryptionManager.
      *
      * @param context application context
-     * @throws IOException if has issues with IO
-     * @throws CertificateException if certificates can not be generated.
-     * @throws NoSuchAlgorithmException if the algorithm for recovering the
-     *                                  entry cannot be found
-     * @throws KeyStoreException if no keystore present
-     * @throws UnrecoverableEntryException if the specified
-     *                                     {@link java.security.KeyStore.ProtectionParameter}
-     *                                     were insufficient or invalid
+     * @throws IOException                        if has issues with IO
+     * @throws CertificateException               if certificates can not be generated.
+     * @throws NoSuchAlgorithmException           if the algorithm for recovering the
+     *                                            entry cannot be found
+     * @throws KeyStoreException                  if no keystore present
+     * @throws UnrecoverableEntryException        if the specified
+     *                                            {@link java.security.KeyStore.ProtectionParameter}
+     *                                            were insufficient or invalid
      * @throws InvalidAlgorithmParameterException if algorithms are parameterized wrong
-     * @throws NoSuchPaddingException if padding setup improperly
-     * @throws InvalidKeyException if RSA keys are not working
-     * @throws NoSuchProviderException if keys provider
+     * @throws NoSuchPaddingException             if padding setup improperly
+     * @throws InvalidKeyException                if RSA keys are not working
+     * @throws NoSuchProviderException            if keys provider
      */
     public SimpleEncryptionManager(Context context)
             throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException,
@@ -162,7 +171,7 @@ public class SimpleEncryptionManager implements EncryptionManager {
     }
 
     private SimpleEncryptionManager(Context context, @Nullable String keyAliasPrefix,
-                            @Nullable byte[] bitShiftingKey)
+                                    @Nullable byte[] bitShiftingKey)
             throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException,
             NoSuchProviderException, NoSuchPaddingException, CertificateException,
             KeyStoreException, UnrecoverableEntryException, InvalidKeyException,
@@ -243,8 +252,7 @@ public class SimpleEncryptionManager implements EncryptionManager {
             byte[] iv = getIv();
             if (isCompatMode) {
                 return encryptAesCompat(bytes, iv);
-            }
-            else {
+            } else {
                 return encryptAes(bytes, iv);
             }
         }
@@ -270,8 +278,7 @@ public class SimpleEncryptionManager implements EncryptionManager {
         if (data != null && data.encryptedData != null) {
             if (isCompatMode) {
                 return decryptAesCompat(data);
-            }
-            else {
+            } else {
                 return decryptAes(data);
             }
         }
@@ -301,6 +308,47 @@ public class SimpleEncryptionManager implements EncryptionManager {
         byte[] result = digest.digest(text.getBytes(DEFAULT_CHARSET));
 
         return toHex(result);
+    }
+
+    @SuppressLint("InlinedApi")
+    @Override
+    public boolean isHardwareBackedKeyStore() {
+        boolean aes = false;
+        boolean rsa = false;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            try {
+                if (aesKey != null) {
+                    SecretKeyFactory factory = null;
+                    factory = SecretKeyFactory.getInstance(aesKey.getAlgorithm(),
+                            KEYSTORE_PROVIDER);
+
+                    KeyInfo keyInfo;
+                    try {
+                        keyInfo = (KeyInfo) factory.getKeySpec(aesKey, KeyInfo.class);
+                        aes = keyInfo.isInsideSecureHardware();
+                    } catch (InvalidKeySpecException e) {
+                        Log.w(TAG, "isHardwareBackedKeyStore: ", e);
+                    }
+                }
+                if (privateKey != null) {
+                    KeyFactory factory = KeyFactory.getInstance(privateKey.getAlgorithm(),
+                            KEYSTORE_PROVIDER);
+                    KeyInfo keyInfo;
+                    try {
+                        keyInfo = factory.getKeySpec(privateKey, KeyInfo.class);
+                        rsa = keyInfo.isInsideSecureHardware();
+                    } catch (InvalidKeySpecException e) {
+                        Log.w(TAG, "isHardwareBackedKeyStore: ", e);
+                    }
+                }
+            } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
+                Log.w(TAG, "isHardwareBackedKeyStore: ", e);
+            }
+        } else {
+            rsa = KeyChain.isBoundKeyAlgorithm(KeyProperties.KEY_ALGORITHM_RSA);
+            aes = KeyChain.isBoundKeyAlgorithm(KeyProperties.KEY_ALGORITHM_AES);
+        }
+        return aes || rsa;
     }
 
     private static String toHex(byte[] data) {
@@ -401,7 +449,7 @@ public class SimpleEncryptionManager implements EncryptionManager {
         return cipher;
     }
 
-    private  EncryptedData encryptAesCompat(byte[] bytes, byte[] iv) throws NoSuchPaddingException,
+    private EncryptedData encryptAesCompat(byte[] bytes, byte[] iv) throws NoSuchPaddingException,
             NoSuchAlgorithmException, NoSuchProviderException, InvalidKeyException,
             BadPaddingException, IllegalBlockSizeException, InvalidAlgorithmParameterException {
         Cipher cipher = getCipherAesCompat(iv, true);

--- a/library/src/test/java/com/okta/oidc/OktaStateTest.java
+++ b/library/src/test/java/com/okta/oidc/OktaStateTest.java
@@ -50,7 +50,7 @@ public class OktaStateTest {
     @Before
     public void setUp() throws Exception {
         mContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        mOktaStorageMock = new OktaStorageMock();
+        mOktaStorageMock = new OktaStorageMock(mContext, false);
         mOktaRepository = new OktaRepository(mOktaStorageMock, mContext, new EncryptionManagerStub());
         mOktaState = new OktaState(mOktaRepository);
     }

--- a/library/src/test/java/com/okta/oidc/util/EncryptedPersistableMock.java
+++ b/library/src/test/java/com/okta/oidc/util/EncryptedPersistableMock.java
@@ -38,7 +38,7 @@ public class EncryptedPersistableMock implements Persistable {
     }
 
     public static final Restore<EncryptedPersistableMock> RESTORE = new Restore<EncryptedPersistableMock>() {
-        private final String KEY = "WebRequest";
+        private final String KEY = "PersistableMock";
 
         public String getKey() {
             return KEY;
@@ -46,7 +46,7 @@ public class EncryptedPersistableMock implements Persistable {
 
         @Override
         public EncryptedPersistableMock restore(String data) {
-            if(data != null) {
+            if (data != null) {
                 return new EncryptedPersistableMock(data);
             }
             return null;

--- a/library/src/test/java/com/okta/oidc/util/EncryptionManagerStub.java
+++ b/library/src/test/java/com/okta/oidc/util/EncryptionManagerStub.java
@@ -13,11 +13,20 @@ public class EncryptionManagerStub implements EncryptionManager {
     public static final String STUPID_SALT = "stupidSalt";
     private static final String DEFAULT_CHARSET = "UTF-8";
 
+    private boolean mHardwareBacked;
+
+    public EncryptionManagerStub() {
+        mHardwareBacked = true;
+    }
+
+    public EncryptionManagerStub(boolean hardwareBacked) {
+        mHardwareBacked = hardwareBacked;
+    }
 
     @Override
     public String encrypt(String value) throws GeneralSecurityException, IOException {
         if (value != null && value.length() > 0) {
-            return value+STUPID_SALT;
+            return value + STUPID_SALT;
         }
         return null;
     }
@@ -25,7 +34,7 @@ public class EncryptionManagerStub implements EncryptionManager {
     @Override
     public String decrypt(String value) throws GeneralSecurityException, IOException {
         if (value != null && value.length() > 0) {
-            return value.replace(STUPID_SALT,"");
+            return value.replace(STUPID_SALT, "");
         } else {
             return null;
         }
@@ -38,6 +47,11 @@ public class EncryptionManagerStub implements EncryptionManager {
         byte[] result = digest.digest(value.getBytes(DEFAULT_CHARSET));
 
         return toHex(result);
+    }
+
+    @Override
+    public boolean isHardwareBackedKeyStore() {
+        return mHardwareBacked;
     }
 
     private static String toHex(byte[] data) {

--- a/library/src/test/java/com/okta/oidc/util/OktaStorageMock.java
+++ b/library/src/test/java/com/okta/oidc/util/OktaStorageMock.java
@@ -14,26 +14,29 @@
  */
 package com.okta.oidc.util;
 
-import com.okta.oidc.storage.OktaStorage;
+import android.content.Context;
+import android.content.SharedPreferences;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.okta.oidc.storage.SimpleOktaStorage;
 
-public class OktaStorageMock implements OktaStorage {
-    private Map<String, String> mInternalStorage = new HashMap<>();
+public class OktaStorageMock extends SimpleOktaStorage {
+    private boolean mRequireHardware;
 
-    @Override
-    public void save(String key, String value) {
-        mInternalStorage.put(key, value);
+    public OktaStorageMock(Context context, boolean hardware) {
+        this(context, null, hardware);
+    }
+
+    public OktaStorageMock(Context context, String prefName, boolean hardware) {
+        super(context, prefName);
+        mRequireHardware = hardware;
     }
 
     @Override
-    public String get(String key) {
-        return mInternalStorage.get(key);
+    public boolean requireHardwareBackedKeyStore() {
+        return mRequireHardware;
     }
 
-    @Override
-    public void delete(String key) {
-        mInternalStorage.remove(key);
+    public SharedPreferences getSharedPreferences() {
+        return prefs;
     }
 }

--- a/library/src/test/java/com/okta/oidc/util/PersistableMock.java
+++ b/library/src/test/java/com/okta/oidc/util/PersistableMock.java
@@ -38,7 +38,7 @@ public class PersistableMock implements Persistable {
     }
 
     public static final Persistable.Restore<PersistableMock> RESTORE = new Persistable.Restore<PersistableMock>() {
-        private final String KEY = "WebRequest";
+        private final String KEY = "PersistableMock";
 
         public String getKey() {
             return KEY;


### PR DESCRIPTION
#### Description:
Add a check to see if device have hardware backed key store.
SDK default implementation will require hardware secure storage.
If the device doesn’t have hardware support the default storage won't persist data to the device. The developer can provide a custom storage to or a custom encryption implementation that doesn’t require hardware support. They can override the default storage and encryption implementations to allow software secure storage.

#### Testing details:
- [x]  Verified basic functionality of change
Verified on a Galaxy S7 since emulators don't provide hardware backed key store.
- [x]  Added tests 

#### Other considerations:
- [x] Has security implications
- [ ] Has UX changes

##### RESOLVES: 
[OKTA-226130](https://oktainc.atlassian.net/browse/OKTA-226130)

#### Primary Reviewer(s):
@sergiymokiyenko-okta 
##### Additional Reviewers:
@ihormartsekha-okta 
@robertdamphousse-okta 
@nbarbettini 
##### Security Reviewer(s) (@ okta/rex-team if necessary):
@danipelaez-okta 
##### UX Reviewer(s) (if necessary):

