### PR TITLE
Task to publish libraries with and without AndroidX.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ buildscript {
 allprojects {
     repositories {
         // Insert local test repo here
-        jcenter()
         google()
+        jcenter()
     }
 }
 
@@ -36,18 +36,17 @@ subprojects {
 }
 
 ext {
-    versionNum = 2
-    versionName = "0.2.0"
+    versionNum = 1
+    versionName = "1.0.0"
     versionDate = new Date()
 
-    // These properties should remain in sync with the values from the AppAuth SDK
     minSdkVersion = 19
     compileSdkVersion = 28
     buildToolsVersion = "28.0.3"
     browserVersion = '1.0.0-beta01'
     appcompatVersion = '1.0.0'
     // SDK dependency versions
-    bintrayVersion = "1.7.3"
+    bintrayVersion = "1.8.4"
     gradlePluginVersion = "1.5"
 
     // Test dependency versions
@@ -59,7 +58,6 @@ ext {
     jsonWebTokenVersion = "0.10.5"
     assertjCoreVersion = "3.10.0"
 
-    buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
     coreVersion = "1.1.1"
     extJUnitVersion = "1.1.0"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,18 +1,16 @@
 apply plugin: "com.android.library"
-apply from: "${rootDir}/gradle/okta-common.gradle"
 apply from: "${rootDir}/gradle/android-common.gradle"
 apply from: "${rootDir}/gradle/style.gradle"
 apply plugin: 'com.jfrog.bintray'
 apply plugin: "com.github.dcendents.android-maven"
-
-version = "${rootProject.versionName}"
+apply plugin: 'maven-publish'
 
 android {
 
     defaultConfig {
-        project.archivesBaseName = "oidc-android"
+        project.archivesBaseName = "oidc-androidx"
         manifestPlaceholders = [
-                "appAuthRedirectScheme": "com.oktapreview.samples-test"
+                "appAuthRedirectScheme": ""
         ]
     }
 
@@ -45,7 +43,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 }
-
 
 buildscript {
     repositories {
@@ -83,27 +80,8 @@ dependencies {
     }
 }
 
-bintray {
-    user = System.getenv("BINTRAY_USER")
-    key = System.getenv("BINTRAY_KEY")
-    configurations = ["archives"]
-    pkg {
-        repo = "com.okta.android"
-        name = "okta-sdk-appauth-android"
-        desc = "Okta AuthClient using AppAuth"
-        userOrg = "okta"
-        licenses = ["Apache-2.0"]
-        websiteUrl = "https://github.com/okta/okta-sdk-appauth-android"
-        vcsUrl = "https://github.com/okta/okta-sdk-appauth-android.git"
-        issueTrackerUrl = "https://github.com/okta/okta-sdk-appauth-android/issues"
-        version {
-            name = "${rootProject.versionName}"
-            desc = "Okta AuthClient using AppAuth"
-            vcsTag = "${rootProject.versionName}"
-        }
-    }
-}
-
 dependencyCheck {
     suppressionFile file("../dependency-suppression.xml").toString()
 }
+
+apply from: 'publish.gradle'

--- a/library/publish.gradle
+++ b/library/publish.gradle
@@ -1,0 +1,76 @@
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
+
+group = "com.okta.android"
+version = "${rootProject.versionName}"
+
+//produces non androidx aar
+task createAndroidAar(type: Exec, dependsOn: "bundleReleaseAar") {
+    def jetifier = System.getenv("ANDROID_HOME") + "/jetifier-standalone/bin/jetifier-standalone"
+    commandLine jetifier, '-r', '-i', "$buildDir/outputs/aar/oidc-androidx-release.aar",
+            '-o', "$buildDir/outputs/aar/oidc-android-release.aar"
+}
+
+publishing {
+    publications {
+        Release(MavenPublication) {
+            artifact("$buildDir/outputs/aar/oidc-android-release.aar")
+            groupId "${group}"
+            artifactId "oidc-android"
+            version "${rootProject.versionName}"
+            pom.withXml {
+                def dependenciesNode = asNode().appendNode('dependencies')
+                configurations.implementation.allDependencies.each {
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', it.group)
+                    dependencyNode.appendNode('artifactId', it.name)
+                    dependencyNode.appendNode('version', it.version)
+                }
+            }
+        }
+        ReleaseX(MavenPublication) {
+            artifact("$buildDir/outputs/aar/oidc-androidx-release.aar")
+            groupId "${group}"
+            artifactId "${android.defaultConfig.project.archivesBaseName}"
+            version "${rootProject.versionName}"
+            pom.withXml {
+                def dependenciesNode = asNode().appendNode('dependencies')
+                configurations.implementation.allDependencies.each {
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', it.group)
+                    dependencyNode.appendNode('artifactId', it.name)
+                    dependencyNode.appendNode('version', it.version)
+                }
+            }
+        }
+    }
+}
+
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+
+bintray {
+    user = properties.getProperty("bintray.user")
+    key = properties.getProperty("bintray.apikey")
+    configurations = ['archives']
+    publications = ['Release']
+    override = true
+    pkg {
+        repo = "com.okta.android"
+        name = "okta-oidc-android"
+        description = "Okta OpenID Connect & OAuth 2.0"
+        userOrg = "okta"
+        publicDownloadNumbers = true
+        licenses = ['Apache-2.0']
+        websiteUrl = "https://github.com/okta/okta-oidc-android"
+        vcsUrl = "https://github.com/okta/okta-oidc-android.git"
+        issueTrackerUrl = "https://github.com/okta/okta-oidc-android/issues"
+        dryRun = false
+        version {
+            name = "${rootProject.versionName}"
+            desc = "Okta OpenID Connect & OAuth 2.0"
+            vcsTag = "${rootProject.versionName}"
+            released = new Date()
+        }
+    }
+}


### PR DESCRIPTION
Jetifier standalone must be downloaded to your ANDROID_HOME directory.

https://developer.android.com/studio/command-line/jetifier

to run the task:
./gradlew bundleReleaseAar createAndroidAar bintrayUpload

#### Description:

#### Testing details:
- [x]  Verified basic functionality of change
- [ ]  Added tests  - no test needed

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes

##### RESOLVES: 
[OKTA-223518](https://oktainc.atlassian.net/browse/OKTA-223518)

#### Primary Reviewer(s):
@sergiymokiyenko-okta 
@ihormartsekha-okta 
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

