### PR TITLE
Refactor HttpRequestBuilder

### DIFF
--- a/app/src/androidTest/java/com/okta/oidc/example/SampleActivityTest.java
+++ b/app/src/androidTest/java/com/okta/oidc/example/SampleActivityTest.java
@@ -369,7 +369,7 @@ public class SampleActivityTest {
         onView(withId(R.id.get_profile)).perform(click());
         onView(withId(R.id.status))
                 .check(matches(withText(
-                        containsString("Profile not supported for OAuth resource"))));
+                        containsString("Invalid operation"))));
     }
 
 

--- a/app/src/main/java/com/okta/oidc/example/SampleActivity.java
+++ b/app/src/main/java/com/okta/oidc/example/SampleActivity.java
@@ -16,8 +16,6 @@
 package com.okta.oidc.example;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
-import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -28,15 +26,11 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.Switch;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.hardware.fingerprint.FingerprintManagerCompat;
-import androidx.core.hardware.fingerprint.FingerprintManagerCompat.AuthenticationResult;
-import androidx.core.os.CancellationSignal;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 
@@ -60,14 +54,10 @@ import com.okta.oidc.net.response.IntrospectInfo;
 import com.okta.oidc.net.response.UserInfo;
 import com.okta.oidc.results.Result;
 import com.okta.oidc.storage.SimpleOktaStorage;
-import com.okta.oidc.storage.security.FingerprintUtils;
-import com.okta.oidc.storage.security.SmartLockEncryptionManager;
 import com.okta.oidc.util.AuthorizationException;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-
-import javax.crypto.Cipher;
 
 /**
  * Sample to test library functionality. Can be used as a starting reference point.
@@ -522,24 +512,20 @@ public class SampleActivity extends AppCompatActivity implements SignInDialog.Si
     private void getProfile() {
         mProgressBar.setVisibility(View.VISIBLE);
         SessionClient client = getSessionClient();
-        try {
-            client.getUserProfile(new RequestCallback<UserInfo, AuthorizationException>() {
-                @Override
-                public void onSuccess(@NonNull UserInfo result) {
-                    mTvStatus.setText(result.toString());
-                    mProgressBar.setVisibility(View.GONE);
-                }
+        client.getUserProfile(new RequestCallback<UserInfo, AuthorizationException>() {
+            @Override
+            public void onSuccess(@NonNull UserInfo result) {
+                mTvStatus.setText(result.toString());
+                mProgressBar.setVisibility(View.GONE);
+            }
 
-                @Override
-                public void onError(String error, AuthorizationException exception) {
-                    Log.d(TAG, error, exception.getCause());
-                    mTvStatus.setText("Error : " + exception.errorDescription);
-                    mProgressBar.setVisibility(View.GONE);
-                }
-            });
-        } catch (UnsupportedOperationException ue) {
-            mTvStatus.setText("Profile not supported for OAuth resource");
-        }
+            @Override
+            public void onError(String error, AuthorizationException exception) {
+                Log.d(TAG, error, exception.getCause());
+                mTvStatus.setText("Error : " + exception.errorDescription);
+                mProgressBar.setVisibility(View.GONE);
+            }
+        });
     }
 
     @Override

--- a/config/checkstyle/suppression.xml
+++ b/config/checkstyle/suppression.xml
@@ -33,7 +33,8 @@
     <suppress checks="Javadoc" files="BaseAuth\.java" />
     <suppress checks="Javadoc" files="SyncAuthClientFactory\.java" />
     <suppress checks="Javadoc" files="SyncSessionClientFactory\.java" />
-
+    <suppress checks="Javadoc" files="SessionClientFactoryImpl\.java" />
+    <suppress checks="Javadoc" files="SyncSessionClientFactoryImpl\.java" />
 
 
     <!-- Suppress javadoc for packages-->

--- a/library/src/main/java/com/okta/oidc/OktaState.java
+++ b/library/src/main/java/com/okta/oidc/OktaState.java
@@ -41,7 +41,7 @@ public class OktaState {
         return mOktaRepo.get(TokenResponse.RESTORE);
     }
 
-    public boolean hasTokenResponse(){
+    public boolean hasTokenResponse() {
         return mOktaRepo.contains(TokenResponse.RESTORE);
     }
 

--- a/library/src/main/java/com/okta/oidc/clients/AuthAPI.java
+++ b/library/src/main/java/com/okta/oidc/clients/AuthAPI.java
@@ -25,7 +25,6 @@ import com.okta.oidc.OIDCConfig;
 import com.okta.oidc.OktaState;
 import com.okta.oidc.net.HttpConnectionFactory;
 import com.okta.oidc.net.request.ConfigurationRequest;
-import com.okta.oidc.net.request.HttpRequest;
 import com.okta.oidc.net.request.HttpRequestBuilder;
 import com.okta.oidc.net.request.ProviderConfiguration;
 import com.okta.oidc.net.request.TokenRequest;
@@ -39,7 +38,6 @@ import com.okta.oidc.storage.security.EncryptionManager;
 import com.okta.oidc.util.AuthorizationException;
 
 import static com.okta.oidc.clients.State.IDLE;
-import static com.okta.oidc.net.request.HttpRequest.Type.TOKEN_EXCHANGE;
 import static com.okta.oidc.util.AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW;
 
 /**
@@ -71,9 +69,8 @@ public class AuthAPI {
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
-    public ConfigurationRequest configurationRequest() {
-        return (ConfigurationRequest) HttpRequestBuilder.newRequest()
-                .request(HttpRequest.Type.CONFIGURATION)
+    public ConfigurationRequest configurationRequest() throws AuthorizationException {
+        return HttpRequestBuilder.newConfigurationRequest()
                 .connectionFactory(mConnectionFactory)
                 .config(mOidcConfig)
                 .createRequest();
@@ -96,9 +93,8 @@ public class AuthAPI {
 
     @WorkerThread
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
-    public TokenRequest tokenExchange(AuthorizeResponse response) {
-        return (TokenRequest) HttpRequestBuilder.newRequest()
-                .request(TOKEN_EXCHANGE)
+    public TokenRequest tokenExchange(AuthorizeResponse response) throws AuthorizationException {
+        return (TokenRequest) HttpRequestBuilder.newTokenRequest()
                 .providerConfiguration(mOktaState.getProviderConfiguration())
                 .config(mOidcConfig)
                 .authRequest((AuthorizeRequest) mOktaState.getAuthorizeRequest())

--- a/library/src/main/java/com/okta/oidc/clients/AuthClientFactoryImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/AuthClientFactoryImpl.java
@@ -41,6 +41,7 @@ public class AuthClientFactoryImpl implements ClientFactory<AuthClient> {
                                    OktaStorage oktaStorage,
                                    EncryptionManager encryptionManager,
                                    HttpConnectionFactory connectionFactory) {
-        return new AuthClientImpl(mCallbackExecutor, oidcConfig, context, oktaStorage, encryptionManager, connectionFactory);
+        return new AuthClientImpl(mCallbackExecutor, oidcConfig, context, oktaStorage,
+                encryptionManager, connectionFactory);
     }
 }

--- a/library/src/main/java/com/okta/oidc/clients/AuthClientImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/AuthClientImpl.java
@@ -44,15 +44,17 @@ class AuthClientImpl implements AuthClient {
                    OktaStorage oktaStorage,
                    EncryptionManager encryptionManager,
                    HttpConnectionFactory httpConnectionFactory) {
-        mSyncNativeAuthClient = new SyncAuthClientFactory().createClient(oidcConfig, context, oktaStorage, encryptionManager, httpConnectionFactory);
-        mSessionImpl = new SessionClientFactoryImpl(executor).createClient(mSyncNativeAuthClient.getSessionClient());
+        mSyncNativeAuthClient = new SyncAuthClientFactory().createClient(oidcConfig, context,
+                oktaStorage, encryptionManager, httpConnectionFactory);
+        mSessionImpl = new SessionClientFactoryImpl(executor)
+                .createClient(mSyncNativeAuthClient.getSessionClient());
         mDispatcher = new RequestDispatcher(executor);
     }
 
     @Override
     @AnyThread
     public void signIn(String sessionToken, AuthenticationPayload payload,
-                      RequestCallback<Result, AuthorizationException> cb) {
+                       RequestCallback<Result, AuthorizationException> cb) {
         mDispatcher.execute(() -> {
             Result result = mSyncNativeAuthClient.signIn(sessionToken, payload);
             if (result.isSuccess()) {

--- a/library/src/main/java/com/okta/oidc/clients/SyncAuthClientFactory.java
+++ b/library/src/main/java/com/okta/oidc/clients/SyncAuthClientFactory.java
@@ -29,6 +29,7 @@ public class SyncAuthClientFactory implements ClientFactory<SyncAuthClient> {
                                            OktaStorage oktaStorage,
                                            EncryptionManager encryptionManager,
                                            HttpConnectionFactory connectionFactory) {
-        return new SyncAuthClientImpl(oidcConfig, context, oktaStorage, encryptionManager, connectionFactory);
+        return new SyncAuthClientImpl(oidcConfig, context, oktaStorage, encryptionManager,
+                connectionFactory);
     }
 }

--- a/library/src/main/java/com/okta/oidc/clients/SyncAuthClientImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/SyncAuthClientImpl.java
@@ -50,7 +50,8 @@ class SyncAuthClientImpl extends AuthAPI implements SyncAuthClient {
 
     @VisibleForTesting
     NativeAuthorizeRequest nativeAuthorizeRequest(String sessionToken,
-                                                  AuthenticationPayload payload) {
+                                                  AuthenticationPayload payload)
+            throws AuthorizationException {
         return new AuthorizeRequest.Builder()
                 .config(mOidcConfig)
                 .providerConfiguration(mOktaState.getProviderConfiguration())

--- a/library/src/main/java/com/okta/oidc/clients/sessions/SessionClientFactoryImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/sessions/SessionClientFactoryImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License,
+ * Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
 package com.okta.oidc.clients.sessions;
 
 import androidx.annotation.RestrictTo;

--- a/library/src/main/java/com/okta/oidc/clients/sessions/SessionClientImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/sessions/SessionClientImpl.java
@@ -46,9 +46,9 @@ class SessionClientImpl implements SessionClient {
         mDispatcher.submit(() -> {
             try {
                 UserInfo userInfo = mSyncSessionClient.getUserProfile();
-                mDispatcher.submitResults(()-> cb.onSuccess(userInfo));
+                mDispatcher.submitResults(() -> cb.onSuccess(userInfo));
             } catch (AuthorizationException ae) {
-                mDispatcher.submitResults(()-> cb.onError(ae.error, ae));
+                mDispatcher.submitResults(() -> cb.onError(ae.error, ae));
             }
         });
     }
@@ -57,10 +57,11 @@ class SessionClientImpl implements SessionClient {
                                 final RequestCallback<IntrospectInfo, AuthorizationException> cb) {
         mDispatcher.submit(() -> {
             try {
-                IntrospectInfo introspectInfo = mSyncSessionClient.introspectToken(token, tokenType);
-                mDispatcher.submitResults(()-> cb.onSuccess(introspectInfo));
+                IntrospectInfo introspectInfo = mSyncSessionClient
+                        .introspectToken(token, tokenType);
+                mDispatcher.submitResults(() -> cb.onSuccess(introspectInfo));
             } catch (AuthorizationException ae) {
-                mDispatcher.submitResults(()-> cb.onError(ae.error, ae));
+                mDispatcher.submitResults(() -> cb.onError(ae.error, ae));
             }
         });
     }
@@ -70,9 +71,9 @@ class SessionClientImpl implements SessionClient {
         mDispatcher.submit(() -> {
             try {
                 Boolean isRevoke = mSyncSessionClient.revokeToken(token);
-                mDispatcher.submitResults(()-> cb.onSuccess(isRevoke));
+                mDispatcher.submitResults(() -> cb.onSuccess(isRevoke));
             } catch (AuthorizationException ae) {
-                mDispatcher.submitResults(()-> cb.onError(ae.error, ae));
+                mDispatcher.submitResults(() -> cb.onError(ae.error, ae));
             }
         });
     }
@@ -83,9 +84,9 @@ class SessionClientImpl implements SessionClient {
         mDispatcher.submit(() -> {
             try {
                 Tokens result = mSyncSessionClient.refreshToken();
-                mDispatcher.submitResults(()-> cb.onSuccess(result));
+                mDispatcher.submitResults(() -> cb.onSuccess(result));
             } catch (AuthorizationException ae) {
-                mDispatcher.submitResults(()-> cb.onError(ae.error, ae));
+                mDispatcher.submitResults(() -> cb.onError(ae.error, ae));
             }
         });
     }
@@ -101,10 +102,11 @@ class SessionClientImpl implements SessionClient {
                                   final RequestCallback<JSONObject, AuthorizationException> cb) {
         mDispatcher.submit(() -> {
             try {
-                JSONObject result = mSyncSessionClient.authorizedRequest(uri, properties, postParameters, method);
-                mDispatcher.submitResults(()-> cb.onSuccess(result));
+                JSONObject result = mSyncSessionClient
+                        .authorizedRequest(uri, properties, postParameters, method);
+                mDispatcher.submitResults(() -> cb.onSuccess(result));
             } catch (AuthorizationException ae) {
-                mDispatcher.submitResults(()-> cb.onError(ae.error, ae));
+                mDispatcher.submitResults(() -> cb.onError(ae.error, ae));
             }
         });
     }

--- a/library/src/main/java/com/okta/oidc/clients/sessions/SyncSessionClientFactoryImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/sessions/SyncSessionClientFactoryImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License,
+ * Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
 package com.okta.oidc.clients.sessions;
 
 import androidx.annotation.RestrictTo;
@@ -8,7 +23,8 @@ import com.okta.oidc.net.HttpConnectionFactory;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class SyncSessionClientFactoryImpl {
-    public SyncSessionClient createClient(OIDCConfig oidcConfig, OktaState oktaState, HttpConnectionFactory connectionFactory) {
+    public SyncSessionClient createClient(OIDCConfig oidcConfig, OktaState oktaState,
+                                          HttpConnectionFactory connectionFactory) {
         return new SyncSessionClientImpl(oidcConfig, oktaState, connectionFactory);
     }
 }

--- a/library/src/main/java/com/okta/oidc/clients/web/SyncWebAuthClient.java
+++ b/library/src/main/java/com/okta/oidc/clients/web/SyncWebAuthClient.java
@@ -23,6 +23,7 @@ import com.okta.oidc.AuthenticationPayload;
 import com.okta.oidc.clients.BaseAuth;
 import com.okta.oidc.clients.sessions.SyncSessionClient;
 import com.okta.oidc.results.Result;
+import com.okta.oidc.util.AuthorizationException;
 
 import java.util.concurrent.ExecutorService;
 
@@ -66,21 +67,23 @@ public interface SyncWebAuthClient extends BaseAuth<SyncSessionClient> {
      * @param activity the activity
      * @param payload  the {@link AuthenticationPayload payload}
      * @return the result
-     * @throws InterruptedException the interrupted exception
+     * @throws InterruptedException   the interrupted exception
+     * @throws AuthorizationException exception due to missing arguments.
      */
     Result signIn(@NonNull FragmentActivity activity,
                   @Nullable AuthenticationPayload payload)
-            throws InterruptedException;
+            throws InterruptedException, AuthorizationException;
 
     /**
      * Sign out from okta. This will clear the browser session
      *
      * @param activity the activity
      * @return the result
-     * @throws InterruptedException the interrupted exception
+     * @throws InterruptedException   the interrupted exception
+     * @throws AuthorizationException exception when trying to log out due to missing arguments.
      */
     Result signOutOfOkta(@NonNull FragmentActivity activity)
-            throws InterruptedException;
+            throws InterruptedException, AuthorizationException;
 
     /**
      * Register a callback for sign in and sign out result status. The callback is triggered when

--- a/library/src/main/java/com/okta/oidc/clients/web/SyncWebAuthClientFactory.java
+++ b/library/src/main/java/com/okta/oidc/clients/web/SyncWebAuthClientFactory.java
@@ -43,7 +43,7 @@ public class SyncWebAuthClientFactory implements ClientFactory<SyncWebAuthClient
                                           OktaStorage oktaStorage,
                                           EncryptionManager encryptionManager,
                                           HttpConnectionFactory connectionFactory) {
-        return new SyncWebAuthClientImpl(oidcConfig, context, oktaStorage, encryptionManager, connectionFactory,
-                mCustomTabColor, mSupportedBrowsers);
+        return new SyncWebAuthClientImpl(oidcConfig, context, oktaStorage, encryptionManager,
+                connectionFactory, mCustomTabColor, mSupportedBrowsers);
     }
 }

--- a/library/src/main/java/com/okta/oidc/clients/web/SyncWebAuthClientImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/web/SyncWebAuthClientImpl.java
@@ -155,7 +155,7 @@ class SyncWebAuthClientImpl extends AuthAPI implements SyncWebAuthClient {
     @WorkerThread
     public Result signIn(@NonNull final FragmentActivity activity,
                          @Nullable AuthenticationPayload payload)
-            throws InterruptedException {
+            throws InterruptedException, AuthorizationException {
         try {
             obtainNewConfiguration();
         } catch (AuthorizationException e) {
@@ -224,7 +224,7 @@ class SyncWebAuthClientImpl extends AuthAPI implements SyncWebAuthClient {
     @Override
     @AnyThread
     public Result signOutOfOkta(@NonNull final FragmentActivity activity)
-            throws InterruptedException {
+            throws InterruptedException, AuthorizationException {
         mOktaState.setCurrentState(State.SIGN_OUT_REQUEST);
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<OktaResultFragment.StateResult> resultWrapper = new AtomicReference<>();

--- a/library/src/main/java/com/okta/oidc/clients/web/WebAuthClientFactory.java
+++ b/library/src/main/java/com/okta/oidc/clients/web/WebAuthClientFactory.java
@@ -50,7 +50,7 @@ public class WebAuthClientFactory implements ClientFactory<WebAuthClient> {
                                       OktaStorage oktaStorage,
                                       EncryptionManager encryptionManager,
                                       HttpConnectionFactory connectionFactory) {
-        return new WebAuthClientImpl(mCallbackExecutor, oidcConfig, context, oktaStorage, encryptionManager, connectionFactory,
-                mCustomTabColor, mSupportedBrowser);
+        return new WebAuthClientImpl(mCallbackExecutor, oidcConfig, context, oktaStorage,
+                encryptionManager, connectionFactory, mCustomTabColor, mSupportedBrowser);
     }
 }

--- a/library/src/main/java/com/okta/oidc/clients/web/WebAuthClientImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/web/WebAuthClientImpl.java
@@ -51,8 +51,11 @@ class WebAuthClientImpl implements WebAuthClient {
                       EncryptionManager encryptionManager,
                       HttpConnectionFactory httpConnectionFactory,
                       int customTabColor, String... supportedBrowsers) {
-        mSyncAuthClient = new SyncWebAuthClientFactory(customTabColor, supportedBrowsers).createClient(oidcConfig, context, oktaStorage, encryptionManager, httpConnectionFactory);
-        mSessionImpl = new SessionClientFactoryImpl(executor).createClient(mSyncAuthClient.getSessionClient());
+        mSyncAuthClient = new SyncWebAuthClientFactory(customTabColor, supportedBrowsers)
+                .createClient(oidcConfig, context, oktaStorage, encryptionManager,
+                        httpConnectionFactory);
+        mSessionImpl = new SessionClientFactoryImpl(executor)
+                .createClient(mSyncAuthClient.getSessionClient());
         mDispatcher = new RequestDispatcher(executor);
     }
 
@@ -123,6 +126,12 @@ class WebAuthClientImpl implements WebAuthClient {
                         mResultCb.onCancel();
                     }
                 });
+            } catch (AuthorizationException e) {
+                mDispatcher.submitResults(() -> {
+                    if (mResultCb != null) {
+                        mResultCb.onError(e.errorDescription, e);
+                    }
+                });
             }
         });
     }
@@ -163,6 +172,12 @@ class WebAuthClientImpl implements WebAuthClient {
                 mDispatcher.submitResults(() -> {
                     if (mResultCb != null) {
                         mResultCb.onCancel();
+                    }
+                });
+            } catch (AuthorizationException e) {
+                mDispatcher.submitResults(() -> {
+                    if (mResultCb != null) {
+                        mResultCb.onError(e.errorDescription, e);
                     }
                 });
             }

--- a/library/src/main/java/com/okta/oidc/net/request/AuthorizedRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/AuthorizedRequest.java
@@ -30,9 +30,10 @@ import java.io.IOException;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class AuthorizedRequest extends BaseRequest<JSONObject, AuthorizationException> {
-    AuthorizedRequest(HttpRequestBuilder b) {
+
+    AuthorizedRequest(HttpRequestBuilder.Authorized b) {
         super();
-        mRequestType = b.mRequestType;
+        mRequestType = Type.AUTHORIZED;
         mUri = b.mUri;
         HttpConnection.Builder builder = new HttpConnection.Builder();
         if (b.mPostParameters != null) {

--- a/library/src/main/java/com/okta/oidc/net/request/ConfigurationRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/ConfigurationRequest.java
@@ -35,9 +35,9 @@ public final class ConfigurationRequest extends
         BaseRequest<ProviderConfiguration, AuthorizationException> {
     private boolean mIsOAuth2;
 
-    ConfigurationRequest(HttpRequestBuilder b) {
+    ConfigurationRequest(HttpRequestBuilder.Configuration b) {
         super();
-        mRequestType = b.mRequestType;
+        mRequestType = Type.CONFIGURATION;
         mIsOAuth2 = b.mConfig.isOAuth2Configuration();
         mUri = b.mConfig.getDiscoveryUri().buildUpon()
                 .appendQueryParameter("client_id", b.mConfig.getClientId()).build();

--- a/library/src/main/java/com/okta/oidc/net/request/HttpRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/HttpRequest.java
@@ -27,7 +27,6 @@ public interface HttpRequest<T, U extends AuthorizationException> {
         CONFIGURATION,
         TOKEN_EXCHANGE,
         AUTHORIZED,
-        PROFILE,
         REVOKE_TOKEN,
         REFRESH_TOKEN,
         INTROSPECT

--- a/library/src/main/java/com/okta/oidc/net/request/HttpRequestBuilder.java
+++ b/library/src/main/java/com/okta/oidc/net/request/HttpRequestBuilder.java
@@ -27,172 +27,317 @@ import com.okta.oidc.net.params.GrantTypes;
 import com.okta.oidc.net.request.web.AuthorizeRequest;
 import com.okta.oidc.net.response.TokenResponse;
 import com.okta.oidc.net.response.web.AuthorizeResponse;
+import com.okta.oidc.util.AuthorizationException;
 
 import java.util.Map;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class HttpRequestBuilder {
-    HttpRequest.Type mRequestType;
-    @Nullable
-    HttpConnectionFactory mConn;
-    OIDCConfig mConfig;
-    ProviderConfiguration mProviderConfiguration;
-    AuthorizeRequest mAuthRequest;
-    AuthorizeResponse mAuthResponse;
-    Map<String, String> mPostParameters;
-    Map<String, String> mProperties;
-    Uri mUri;
-    HttpConnection.RequestMethod mRequestMethod;
-    String mTokenToRevoke;
-    TokenResponse mTokenResponse;
-    String mGrantType;
 
-    String mIntrospectToken;
-    String mTokenTypeHint;
-
-    private HttpRequestBuilder() {
+    public static Authorized newAuthorizedRequest() {
+        return new Authorized();
     }
 
-    private void validate(HttpRequest.Type type) {
-        if (mConfig == null) {
-            throw new IllegalStateException("Invalid config");
-        }
-        if (mProviderConfiguration == null && type != HttpRequest.Type.CONFIGURATION) {
-            throw new IllegalStateException("Missing service configuration");
-        }
-        switch (type) {
-            case CONFIGURATION:
-                break; //NO-OP
-            case AUTHORIZED:
-                if (mTokenResponse == null || mTokenResponse.getAccessToken() == null
-                        || mTokenResponse.getIdToken() == null || mUri == null) {
-                    throw new IllegalStateException("Not logged in or invalid uri");
-                }
-                break;
-            case TOKEN_EXCHANGE:
-                if (mAuthRequest == null || mAuthResponse == null) {
-                    throw new IllegalStateException("Missing auth request or response");
-                }
-                break;
-            case PROFILE:
-                if (mTokenResponse == null || mTokenResponse.getAccessToken() == null
-                        || mTokenResponse.getIdToken() == null) {
-                    throw new IllegalStateException("Not logged in");
-                }
-                break;
-            case REVOKE_TOKEN:
-                if (mTokenToRevoke == null) {
-                    throw new IllegalStateException("Invalid token");
-                }
-                break;
-            case REFRESH_TOKEN:
-                if (mTokenResponse == null || mTokenResponse.getRefreshToken() == null
-                        || mTokenResponse.getScope() == null) {
-                    throw new IllegalStateException("No refresh token found");
-                }
-                break;
-            case INTROSPECT:
-                if (mIntrospectToken == null || mTokenTypeHint == null) {
-                    throw new IllegalStateException("Invalid token or missing hint");
-                }
-                break;
-            default:
-        }
+    public static Configuration newConfigurationRequest() {
+        return new Configuration();
     }
 
-    public static HttpRequestBuilder newRequest() {
-        return new HttpRequestBuilder();
+    public static TokenExchange newTokenRequest() {
+        return new TokenExchange();
     }
 
-    public HttpRequest createRequest() {
-        validate(mRequestType);
-        switch (mRequestType) {
-            case CONFIGURATION:
-                return new ConfigurationRequest(this);
-            case TOKEN_EXCHANGE:
-                mGrantType = GrantTypes.AUTHORIZATION_CODE;
-                return new TokenRequest(this);
-            case AUTHORIZED:
-                return new AuthorizedRequest(this);
-            case PROFILE:
-                mUri = Uri.parse(mProviderConfiguration.userinfo_endpoint);
-                mRequestMethod = HttpConnection.RequestMethod.POST;
-                return new AuthorizedRequest(this);
-            case REVOKE_TOKEN:
-                return new RevokeTokenRequest(this);
-            case REFRESH_TOKEN:
-                mGrantType = GrantTypes.REFRESH_TOKEN;
-                return new RefreshTokenRequest(this);
-            case INTROSPECT:
-                return new IntrospectRequest(this);
-            default:
-                throw new IllegalArgumentException("Invalid request of type: " + mRequestType);
+    public static RevokeToken newRevokeTokenRequest() {
+        return new RevokeToken();
+    }
+
+    public static Profile newProfileRequest() {
+        return new Profile();
+    }
+
+    public static RefreshToken newRefreshTokenRequest() {
+        return new RefreshToken();
+    }
+
+    public static Introspect newIntrospectRequest() {
+        return new Introspect();
+    }
+
+    private abstract static class Builder<T extends Builder<T>> {
+        @Nullable
+        HttpConnectionFactory mConn;
+        OIDCConfig mConfig;
+        ProviderConfiguration mProviderConfiguration;
+
+        /*
+         * prevent unchecked cast warning.
+         */
+        abstract T toThis();
+
+        protected void validate(boolean isConfigurationRequest) throws AuthorizationException {
+            if (mConfig == null) {
+                throwException("Invalid config");
+            }
+            if (mProviderConfiguration == null && !isConfigurationRequest) {
+                throwException("Missing service configuration");
+            }
+        }
+
+        public T connectionFactory(HttpConnectionFactory conn) {
+            mConn = conn;
+            return toThis();
+        }
+
+        public T config(OIDCConfig config) {
+            mConfig = config;
+            return toThis();
+        }
+
+        public T providerConfiguration(ProviderConfiguration providerConfiguration) {
+            mProviderConfiguration = providerConfiguration;
+            return toThis();
+        }
+
+        public abstract HttpRequest createRequest() throws AuthorizationException;
+    }
+
+    public static class Configuration extends Builder<Configuration> {
+        private Configuration() {
+        }
+
+        @Override
+        Configuration toThis() {
+            return this;
+        }
+
+        @Override
+        public ConfigurationRequest createRequest() throws AuthorizationException {
+            validate(true);
+            return new ConfigurationRequest(this);
         }
     }
 
-    public HttpRequestBuilder request(HttpRequest.Type type) {
-        mRequestType = type;
-        return this;
+    public static class Authorized extends Builder<Authorized> {
+        Uri mUri;
+        TokenResponse mTokenResponse;
+        Map<String, String> mPostParameters;
+        Map<String, String> mProperties;
+        HttpConnection.RequestMethod mRequestMethod;
+
+        private Authorized() {
+        }
+
+        @Override
+        Authorized toThis() {
+            return this;
+        }
+
+        protected void validate(boolean isConfigurationRequest) throws AuthorizationException {
+            super.validate(isConfigurationRequest);
+            if (mTokenResponse == null || mTokenResponse.getIdToken() == null || mUri == null) {
+                throwException("Not logged in or invalid uri");
+            }
+        }
+
+        public Authorized uri(Uri uri) {
+            mUri = uri;
+            return this;
+        }
+
+        public Authorized tokenResponse(TokenResponse tokenResponse) {
+            mTokenResponse = tokenResponse;
+            return this;
+        }
+
+        public Authorized postParameters(Map<String, String> postParameters) {
+            mPostParameters = postParameters;
+            return this;
+        }
+
+        public Authorized properties(Map<String, String> properties) {
+            mProperties = properties;
+            return this;
+        }
+
+        public Authorized httpRequestMethod(HttpConnection.RequestMethod requestMethod) {
+            mRequestMethod = requestMethod;
+            return this;
+        }
+
+        @Override
+        public AuthorizedRequest createRequest() throws AuthorizationException {
+            validate(false);
+            return new AuthorizedRequest(this);
+        }
     }
 
-    public HttpRequestBuilder connectionFactory(HttpConnectionFactory conn) {
-        mConn = conn;
-        return this;
+    public static class TokenExchange extends Builder<TokenExchange> {
+        AuthorizeRequest mAuthRequest;
+        AuthorizeResponse mAuthResponse;
+        String mGrantType;
+
+        private TokenExchange() {
+        }
+
+        @Override
+        TokenExchange toThis() {
+            return this;
+        }
+
+        @Override
+        protected void validate(boolean isConfigurationRequest) throws AuthorizationException {
+            super.validate(isConfigurationRequest);
+            if (mAuthRequest == null || mAuthResponse == null) {
+                throwException("Missing auth request or response");
+            }
+        }
+
+        public TokenExchange authRequest(AuthorizeRequest authRequest) {
+            mAuthRequest = authRequest;
+            return this;
+        }
+
+        public TokenExchange authResponse(AuthorizeResponse authResponse) {
+            mAuthResponse = authResponse;
+            return this;
+        }
+
+        @Override
+        public TokenRequest createRequest() throws AuthorizationException {
+            validate(false);
+            mGrantType = GrantTypes.AUTHORIZATION_CODE;
+            return new TokenRequest(this);
+        }
     }
 
-    public HttpRequestBuilder config(OIDCConfig config) {
-        mConfig = config;
-        return this;
+    public static class RefreshToken extends Builder<RefreshToken> {
+        TokenResponse mTokenResponse;
+        String mGrantType;
+
+        private RefreshToken() {
+        }
+
+        @Override
+        RefreshToken toThis() {
+            return this;
+        }
+
+        public RefreshToken tokenResponse(TokenResponse tokenResponse) {
+            mTokenResponse = tokenResponse;
+            return this;
+        }
+
+        @Override
+        protected void validate(boolean isConfigurationRequest) throws AuthorizationException {
+            super.validate(isConfigurationRequest);
+            if (mTokenResponse == null || mTokenResponse.getRefreshToken() == null) {
+                throwException("No refresh token found");
+            }
+        }
+
+        @Override
+        public RefreshTokenRequest createRequest() throws AuthorizationException {
+            validate(false);
+            mGrantType = GrantTypes.REFRESH_TOKEN;
+            return new RefreshTokenRequest(this);
+        }
     }
 
-    public HttpRequestBuilder providerConfiguration(ProviderConfiguration providerConfiguration) {
-        mProviderConfiguration = providerConfiguration;
-        return this;
+    public static class RevokeToken extends Builder<RevokeToken> {
+        String mTokenToRevoke;
+
+        private RevokeToken() {
+        }
+
+        @Override
+        RevokeToken toThis() {
+            return this;
+        }
+
+        @Override
+        protected void validate(boolean isConfigurationRequest) throws AuthorizationException {
+            super.validate(isConfigurationRequest);
+            if (mTokenToRevoke == null) {
+                throwException("Invalid token");
+            }
+        }
+
+        public RevokeToken tokenToRevoke(String token) {
+            mTokenToRevoke = token;
+            return this;
+        }
+
+        @Override
+        public RevokeTokenRequest createRequest() throws AuthorizationException {
+            validate(false);
+            return new RevokeTokenRequest(this);
+        }
     }
 
-    public HttpRequestBuilder tokenResponse(TokenResponse tokenResponse) {
-        mTokenResponse = tokenResponse;
-        return this;
+    public static class Profile extends Builder<Profile> {
+        TokenResponse mTokenResponse;
+
+        private Profile() {
+        }
+
+        @Override
+        Profile toThis() {
+            return this;
+        }
+
+        public Profile tokenResponse(TokenResponse tokenResponse) {
+            mTokenResponse = tokenResponse;
+            return this;
+        }
+
+        @Override
+        public AuthorizedRequest createRequest() throws AuthorizationException {
+            Authorized authorized = newAuthorizedRequest();
+            authorized.tokenResponse(mTokenResponse);
+            authorized.config(mConfig);
+            authorized.providerConfiguration(mProviderConfiguration);
+            authorized.uri(Uri.parse(mProviderConfiguration.userinfo_endpoint));
+            authorized.httpRequestMethod(HttpConnection.RequestMethod.POST);
+            authorized.validate(false);
+            return new AuthorizedRequest(authorized);
+        }
     }
 
-    public HttpRequestBuilder authRequest(AuthorizeRequest authRequest) {
-        mAuthRequest = authRequest;
-        return this;
+    public static class Introspect extends Builder<Introspect> {
+        String mIntrospectToken;
+        String mTokenTypeHint;
+
+        private Introspect() {
+        }
+
+        @Override
+        Introspect toThis() {
+            return this;
+        }
+
+        @Override
+        protected void validate(boolean isConfigurationRequest) throws AuthorizationException {
+            super.validate(isConfigurationRequest);
+            if (mIntrospectToken == null || mTokenTypeHint == null) {
+                throwException("Invalid token or missing hint");
+            }
+        }
+
+        public Introspect introspect(String token, String tokenType) {
+            mIntrospectToken = token;
+            mTokenTypeHint = tokenType;
+            return this;
+        }
+
+        @Override
+        public IntrospectRequest createRequest() throws AuthorizationException {
+            validate(false);
+            return new IntrospectRequest(this);
+        }
     }
 
-    public HttpRequestBuilder authResponse(AuthorizeResponse authResponse) {
-        mAuthResponse = authResponse;
-        return this;
-    }
+    private static void throwException(String message) throws AuthorizationException {
+        throw new AuthorizationException(message,
+                new RuntimeException());
 
-    public HttpRequestBuilder postParameters(Map<String, String> postParameters) {
-        mPostParameters = postParameters;
-        return this;
-    }
-
-    public HttpRequestBuilder properties(Map<String, String> properties) {
-        mProperties = properties;
-        return this;
-    }
-
-    public HttpRequestBuilder uri(Uri uri) {
-        mUri = uri;
-        return this;
-    }
-
-    public HttpRequestBuilder httpRequestMethod(HttpConnection.RequestMethod requestMethod) {
-        mRequestMethod = requestMethod;
-        return this;
-    }
-
-    public HttpRequestBuilder tokenToRevoke(String token) {
-        mTokenToRevoke = token;
-        return this;
-    }
-
-    public HttpRequestBuilder introspect(String token, String tokenType) {
-        mIntrospectToken = token;
-        mTokenTypeHint = tokenType;
-        return this;
     }
 }

--- a/library/src/main/java/com/okta/oidc/net/request/IntrospectRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/IntrospectRequest.java
@@ -35,9 +35,9 @@ import java.io.IOException;
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class IntrospectRequest extends
         BaseRequest<IntrospectInfo, AuthorizationException> {
-    public IntrospectRequest(HttpRequestBuilder b) {
+    public IntrospectRequest(HttpRequestBuilder.Introspect b) {
         super();
-        mRequestType = b.mRequestType;
+        mRequestType = Type.INTROSPECT;
         mUri = Uri.parse(b.mProviderConfiguration.introspection_endpoint).buildUpon()
                 .appendQueryParameter("client_id", b.mConfig.getClientId())
                 .appendQueryParameter("token", b.mIntrospectToken)

--- a/library/src/main/java/com/okta/oidc/net/request/RefreshTokenRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/RefreshTokenRequest.java
@@ -15,8 +15,11 @@
 
 package com.okta.oidc.net.request;
 
+import android.net.Uri;
+
 import androidx.annotation.RestrictTo;
 
+import com.okta.oidc.net.HttpConnection;
 import com.okta.oidc.util.AsciiStringListUtil;
 
 import java.util.Collections;
@@ -25,18 +28,28 @@ import java.util.Map;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class RefreshTokenRequest extends TokenRequest {
-    RefreshTokenRequest(HttpRequestBuilder b) {
-        super(b);
+    RefreshTokenRequest(HttpRequestBuilder.RefreshToken b) {
+        super();
+        mRequestType = Type.REFRESH_TOKEN;
+        scope = b.mTokenResponse.getScope();
+        mConfig = b.mConfig;
+        refresh_token = b.mTokenResponse.getRefreshToken();
+        mProviderConfiguration = b.mProviderConfiguration;
+        mUri = Uri.parse(b.mProviderConfiguration.token_endpoint);
+        client_id = b.mConfig.getClientId();
+        grant_type = b.mGrantType;
+        mConnection = new HttpConnection.Builder()
+                .setRequestMethod(HttpConnection.RequestMethod.POST)
+                .setRequestProperty("Accept", HttpConnection.JSON_CONTENT_TYPE)
+                .setPostParameters(buildParameters())
+                .create(b.mConn);
     }
 
-    protected Map<String, String> buildParameters(HttpRequestBuilder b) {
-        scope = b.mTokenResponse.getScope();
-        refresh_token = b.mTokenResponse.getRefreshToken();
+    private Map<String, String> buildParameters() {
         Map<String, String> params = new HashMap<>();
         params.put("client_id", client_id);
         params.put("grant_type", grant_type);
         params.put("refresh_token", refresh_token);
-
         params.put("scope", AsciiStringListUtil.iterableToString(Collections.singletonList(scope)));
         return params;
     }

--- a/library/src/main/java/com/okta/oidc/net/request/RevokeTokenRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/RevokeTokenRequest.java
@@ -30,9 +30,9 @@ import java.net.HttpURLConnection;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class RevokeTokenRequest extends BaseRequest<Boolean, AuthorizationException> {
-    RevokeTokenRequest(HttpRequestBuilder b) {
+    RevokeTokenRequest(HttpRequestBuilder.RevokeToken b) {
         super();
-        mRequestType = b.mRequestType;
+        mRequestType = Type.REVOKE_TOKEN;
         mUri = Uri.parse(b.mProviderConfiguration.revocation_endpoint).buildUpon()
                 .appendQueryParameter("client_id", b.mConfig.getClientId())
                 .appendQueryParameter("token", b.mTokenToRevoke)

--- a/library/src/main/java/com/okta/oidc/net/request/TokenRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/TokenRequest.java
@@ -58,15 +58,18 @@ public class TokenRequest extends BaseRequest<TokenResponse, AuthorizationExcept
     protected String scope;
     private String username;
     private String nonce;
-    private OIDCConfig mConfig;
+    protected OIDCConfig mConfig;
     protected ProviderConfiguration mProviderConfiguration;
 
     //if set, used to verify idtoken auth_Time
     private String mMaxAge;
 
-    TokenRequest(HttpRequestBuilder b) {
+    TokenRequest() {
+    }
+
+    TokenRequest(HttpRequestBuilder.TokenExchange b) {
         super();
-        mRequestType = b.mRequestType;
+        mRequestType = Type.TOKEN_EXCHANGE;
         mConfig = b.mConfig;
         mProviderConfiguration = b.mProviderConfiguration;
         mUri = Uri.parse(mProviderConfiguration.token_endpoint);
@@ -115,7 +118,7 @@ public class TokenRequest extends BaseRequest<TokenResponse, AuthorizationExcept
         return mMaxAge;
     }
 
-    protected Map<String, String> buildParameters(HttpRequestBuilder b) {
+    protected Map<String, String> buildParameters(HttpRequestBuilder.TokenExchange b) {
         code_verifier = b.mAuthRequest.getCodeVerifier();
         nonce = b.mAuthRequest.getNonce();
         code = b.mAuthResponse.getCode();

--- a/library/src/main/java/com/okta/oidc/net/request/web/AuthorizeRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/web/AuthorizeRequest.java
@@ -30,6 +30,7 @@ import com.okta.oidc.net.params.ResponseType;
 import com.okta.oidc.net.request.NativeAuthorizeRequest;
 import com.okta.oidc.net.request.ProviderConfiguration;
 import com.okta.oidc.util.AsciiStringListUtil;
+import com.okta.oidc.util.AuthorizationException;
 import com.okta.oidc.util.CodeVerifierUtil;
 
 import java.util.Arrays;
@@ -142,33 +143,35 @@ public class AuthorizeRequest extends WebRequest {
             }
         }
 
-        private void validate(boolean isNative) {
+        private void validate(boolean isNative) throws AuthorizationException {
             if (TextUtils.isEmpty(mMap.get(AUTHORIZE_ENDPOINT))) {
-                throw new IllegalArgumentException("authorize_endpoint missing");
+                throw new AuthorizationException("authorize_endpoint missing",
+                        new RuntimeException());
             }
             if (TextUtils.isEmpty(mMap.get(CODE_CHALLENGE))) {
-                throw new IllegalArgumentException("code_challenge missing");
+                throw new AuthorizationException("code_challenge missing", new RuntimeException());
             }
             if (TextUtils.isEmpty(mMap.get(CODE_CHALLENGE_METHOD))) {
-                throw new IllegalArgumentException("code_challenge_method missing");
+                throw new AuthorizationException("code_challenge_method missing",
+                        new RuntimeException());
             }
             if (TextUtils.isEmpty(mMap.get(NONCE))) {
-                throw new IllegalArgumentException("nonce missing");
+                throw new AuthorizationException("nonce missing", new RuntimeException());
             }
             if (TextUtils.isEmpty(mMap.get(REDIRECT_URI))) {
-                throw new IllegalArgumentException("redirect_uri missing");
+                throw new AuthorizationException("redirect_uri missing", new RuntimeException());
             }
             if (TextUtils.isEmpty(mMap.get(RESPONSE_TYPE))) {
-                throw new IllegalArgumentException("response_type missing");
+                throw new AuthorizationException("response_type missing", new RuntimeException());
             }
             if (TextUtils.isEmpty(mMap.get(SCOPE))) {
-                throw new IllegalArgumentException("scope missing");
+                throw new AuthorizationException("scope missing", new RuntimeException());
             }
             if (TextUtils.isEmpty(mMap.get(STATE))) {
-                throw new IllegalArgumentException("state missing");
+                throw new AuthorizationException("state missing", new RuntimeException());
             }
             if (isNative && TextUtils.isEmpty(mMap.get(SESSION_TOKEN))) {
-                throw new IllegalArgumentException("sessionToken is missing");
+                throw new AuthorizationException("sessionToken is missing", new RuntimeException());
             }
         }
 
@@ -182,7 +185,7 @@ public class AuthorizeRequest extends WebRequest {
             setCodeVerifier(null);
         }
 
-        public AuthorizeRequest create() {
+        public AuthorizeRequest create() throws AuthorizationException {
             if (mParameters.mPayloadParams != null) {
                 mMap.putAll(mParameters.mPayloadParams);
             }
@@ -190,7 +193,8 @@ public class AuthorizeRequest extends WebRequest {
             return new AuthorizeRequest(mParameters);
         }
 
-        public NativeAuthorizeRequest createNativeRequest(HttpConnectionFactory factory) {
+        public NativeAuthorizeRequest createNativeRequest(HttpConnectionFactory factory)
+                throws AuthorizationException {
             if (mParameters.mPayloadParams != null) {
                 mMap.putAll(mParameters.mPayloadParams);
             }

--- a/library/src/main/java/com/okta/oidc/net/request/web/LogoutRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/web/LogoutRequest.java
@@ -26,6 +26,7 @@ import com.google.gson.Gson;
 import com.okta.oidc.OIDCConfig;
 import com.okta.oidc.net.request.ProviderConfiguration;
 import com.okta.oidc.net.response.TokenResponse;
+import com.okta.oidc.util.AuthorizationException;
 import com.okta.oidc.util.CodeVerifierUtil;
 
 //https://developer.okta.com/docs/api/resources/oidc#logout
@@ -90,16 +91,19 @@ public class LogoutRequest extends WebRequest {
     public static final class Builder {
         private Parameters mParameters;
 
-        private void validate() {
+        private void validate() throws AuthorizationException {
             if (TextUtils.isEmpty(mParameters.end_session_endpoint)) {
-                throw new IllegalArgumentException("end_session_endpoint missing");
+                throw new AuthorizationException("end_session_endpoint missing",
+                        new RuntimeException());
             }
             if (TextUtils.isEmpty(mParameters.id_token_hint)) {
-                throw new IllegalArgumentException("id_token_hint missing");
+                throw new AuthorizationException("id_token_hint missing", new RuntimeException());
             }
             if (TextUtils.isEmpty(mParameters.post_logout_redirect_uri)) {
-                throw new IllegalArgumentException("post_logout_redirect_uri missing");
+                throw new AuthorizationException("post_logout_redirect_uri missing",
+                        new RuntimeException());
             }
+
         }
 
         public Builder() {
@@ -107,7 +111,7 @@ public class LogoutRequest extends WebRequest {
             mParameters.state = CodeVerifierUtil.generateRandomState();
         }
 
-        public LogoutRequest create() {
+        public LogoutRequest create() throws AuthorizationException {
             validate();
             return new LogoutRequest(mParameters);
         }

--- a/library/src/main/java/com/okta/oidc/util/AuthorizationException.java
+++ b/library/src/main/java/com/okta/oidc/util/AuthorizationException.java
@@ -658,6 +658,15 @@ public final class AuthorizationException extends Exception {
     }
 
     /**
+     * Instantiates an authorization request with description and root cause information.
+     */
+    public AuthorizationException(
+            @NonNull String errorDescription,
+            @NonNull Throwable rootCause) {
+        this(TYPE_GENERAL_ERROR, TYPE_GENERAL_ERROR, null, errorDescription, null, rootCause);
+    }
+
+    /**
      * Produces a JSON representation of the authorization exception, for transmission or
      * withStorage. This does not include any provided root cause.
      */

--- a/library/src/test/java/com/okta/oidc/OktaResultFragmentTest.java
+++ b/library/src/test/java/com/okta/oidc/OktaResultFragmentTest.java
@@ -77,7 +77,7 @@ public class OktaResultFragmentTest {
 
 
     @Test
-    public void handleAuthorizationResponseLoginSuccess() {
+    public void handleAuthorizationResponseLoginSuccess() throws AuthorizationException {
         OktaResultFragment.addLoginFragment(TestValues.getAuthorizeRequest(mConfig, null), 0, mActivity, listener, new String[]{});
 
         Intent intent = new Intent();
@@ -95,7 +95,7 @@ public class OktaResultFragmentTest {
     }
 
     @Test
-    public void handleAuthorizationResponseLoginFailed() {
+    public void handleAuthorizationResponseLoginFailed() throws AuthorizationException {
         OktaResultFragment.addLoginFragment(TestValues.getAuthorizeRequest(mConfig, null), 0, mActivity, listener, new String[]{});
 
         Intent intent = new Intent();
@@ -114,7 +114,7 @@ public class OktaResultFragmentTest {
     }
 
     @Test
-    public void handleAuthorizationResponseLogoutSuccess() {
+    public void handleAuthorizationResponseLogoutSuccess() throws AuthorizationException {
         OktaResultFragment.addLogoutFragment(TestValues.getAuthorizeRequest(mConfig, null), 0, mActivity, listener, new String[]{});
 
         Intent intent = new Intent();
@@ -132,7 +132,7 @@ public class OktaResultFragmentTest {
     }
 
     @Test
-    public void handleAuthorizationResponseLogoutFailed() {
+    public void handleAuthorizationResponseLogoutFailed() throws AuthorizationException {
         OktaResultFragment.addLogoutFragment(TestValues.getAuthorizeRequest(mConfig, null), 0, mActivity, listener, new String[]{});
 
         Intent intent = new Intent();
@@ -151,7 +151,7 @@ public class OktaResultFragmentTest {
     }
 
     @Test
-    public void handleAuthorizationResponseWithEmptyIntent() {
+    public void handleAuthorizationResponseWithEmptyIntent() throws AuthorizationException {
         OktaResultFragment.addLoginFragment(TestValues.getAuthorizeRequest(mConfig, null), 0, mActivity, listener, new String[]{});
 
         Intent intent = new Intent();
@@ -171,7 +171,7 @@ public class OktaResultFragmentTest {
     }
 
     @Test
-    public void handleAuthorizationResponseWithInvalidJsonErrorInIntent() {
+    public void handleAuthorizationResponseWithInvalidJsonErrorInIntent() throws AuthorizationException {
         OktaResultFragment.addLoginFragment(TestValues.getAuthorizeRequest(mConfig, null), 0, mActivity, listener, new String[]{});
 
         Intent intent = new Intent();
@@ -190,7 +190,7 @@ public class OktaResultFragmentTest {
     }
 
     @Test
-    public void handleAuthorizationResponseWithValidJsonErrorInIntent() {
+    public void handleAuthorizationResponseWithValidJsonErrorInIntent() throws AuthorizationException {
         OktaResultFragment.addLoginFragment(TestValues.getAuthorizeRequest(mConfig, null), 0, mActivity, listener, new String[]{});
 
         Intent intent = new Intent();

--- a/library/src/test/java/com/okta/oidc/OktaStateTest.java
+++ b/library/src/test/java/com/okta/oidc/OktaStateTest.java
@@ -23,6 +23,7 @@ import com.okta.oidc.net.request.web.AuthorizeRequest;
 import com.okta.oidc.net.request.web.WebRequest;
 import com.okta.oidc.net.response.TokenResponse;
 import com.okta.oidc.storage.OktaRepository;
+import com.okta.oidc.util.AuthorizationException;
 import com.okta.oidc.util.EncryptionManagerStub;
 import com.okta.oidc.util.OktaStorageMock;
 import com.okta.oidc.util.TestValues;
@@ -56,7 +57,7 @@ public class OktaStateTest {
     }
 
     @Test
-    public void getAuthorizeRequest() {
+    public void getAuthorizeRequest() throws AuthorizationException {
         WebRequest authorizedRequest = TestValues.getAuthorizeRequest(TestValues.getConfigWithUrl(CUSTOM_URL), null);
         mOktaState.save(authorizedRequest);
 

--- a/library/src/test/java/com/okta/oidc/clients/sessions/SyncSessionClientImplTest.java
+++ b/library/src/test/java/com/okta/oidc/clients/sessions/SyncSessionClientImplTest.java
@@ -123,7 +123,7 @@ public class SyncSessionClientImplTest {
 
 
     @Test
-    public void clear_success() {
+    public void clear_success() throws AuthorizationException {
         mOktaState.save(mProviderConfig);
         mOktaState.save(mTokenResponse);
         mOktaState.save(TestValues.getAuthorizeRequest(mConfig, null));
@@ -201,7 +201,7 @@ public class SyncSessionClientImplTest {
     @Test
     public void userProfileRequestOAuth2() throws InterruptedException, AuthorizationException,
             JSONException {
-        mExpectedEx.expect(UnsupportedOperationException.class);
+        mExpectedEx.expect(AuthorizationException.class);
         //create sessionclient from oauth2 resource
         OIDCConfig oauth2Config = TestValues
                 .getConfigWithUrl(mEndPoint.getUrl() + "/oauth2/default/");

--- a/library/src/test/java/com/okta/oidc/net/request/AuthorizedRequestTest.java
+++ b/library/src/test/java/com/okta/oidc/net/request/AuthorizedRequestTest.java
@@ -65,8 +65,7 @@ public class AuthorizedRequestTest {
         mProviderConfig = TestValues.getProviderConfiguration(url);
         mTokenResponse = new Gson().fromJson(JsonStrings.TOKEN_RESPONSE, TokenResponse.class);
 
-        mRequest = (AuthorizedRequest) HttpRequestBuilder.newRequest()
-                .request(HttpRequest.Type.AUTHORIZED)
+        mRequest = HttpRequestBuilder.newAuthorizedRequest()
                 .uri(Uri.parse(mEndPoint.getUrl()))
                 .httpRequestMethod(HttpConnection.RequestMethod.POST)
                 .config(config)

--- a/library/src/test/java/com/okta/oidc/net/request/ConfigurationRequestTest.java
+++ b/library/src/test/java/com/okta/oidc/net/request/ConfigurationRequestTest.java
@@ -54,14 +54,12 @@ public class ConfigurationRequestTest {
         mEndPoint = new MockEndPoint();
         String url = mEndPoint.getUrl();
         OIDCConfig config = TestValues.getConfigWithUrl(url);
-        mRequest = (ConfigurationRequest) HttpRequestBuilder.newRequest()
-                .request(HttpRequest.Type.CONFIGURATION)
+        mRequest = HttpRequestBuilder.newConfigurationRequest()
                 .config(config)
                 .createRequest();
 
         OIDCConfig configOAuth2 = TestValues.getConfigWithUrl(url + "/oauth2/default/");
-        mRequestOAuth2 = (ConfigurationRequest) HttpRequestBuilder.newRequest()
-                .request(HttpRequest.Type.CONFIGURATION)
+        mRequestOAuth2 = HttpRequestBuilder.newConfigurationRequest()
                 .config(configOAuth2)
                 .createRequest();
         mCallbackExecutor = Executors.newSingleThreadExecutor();

--- a/library/src/test/java/com/okta/oidc/net/request/web/AuthorizeRequestTest.java
+++ b/library/src/test/java/com/okta/oidc/net/request/web/AuthorizeRequestTest.java
@@ -21,6 +21,7 @@ import com.okta.oidc.AuthenticationPayload;
 import com.okta.oidc.OIDCConfig;
 import com.okta.oidc.net.request.ProviderConfiguration;
 import com.okta.oidc.util.AsciiStringListUtil;
+import com.okta.oidc.util.AuthorizationException;
 import com.okta.oidc.util.CodeVerifierUtil;
 import com.okta.oidc.util.TestValues;
 
@@ -57,7 +58,7 @@ public class AuthorizeRequestTest {
     private ProviderConfiguration mProviderConfig;
 
     @Before
-    public void setUp() {
+    public void setUp() throws AuthorizationException {
         mCodeVerifier = CodeVerifierUtil.generateRandomCodeVerifier();
         mConfig = TestValues.getConfigWithUrl(CUSTOM_URL);
         mProviderConfig = TestValues.getProviderConfiguration(CUSTOM_URL);
@@ -79,34 +80,34 @@ public class AuthorizeRequestTest {
     }
 
     @Test
-    public void testBuilderFailEndpoint() {
+    public void testBuilderFailEndpoint() throws AuthorizationException {
         AuthorizeRequest.Builder builder = new AuthorizeRequest.Builder();
-        mExpectedEx.expect(IllegalArgumentException.class);
+        mExpectedEx.expect(AuthorizationException.class);
         mExpectedEx.expectMessage("authorize_endpoint missing");
         builder.create();
     }
 
     @Test
-    public void testBuilderFailRedirectUri() {
+    public void testBuilderFailRedirectUri() throws AuthorizationException {
         AuthorizeRequest.Builder builder = new AuthorizeRequest.Builder();
         builder.authorizeEndpoint(mConfig.getDiscoveryUri().toString());
-        mExpectedEx.expect(IllegalArgumentException.class);
+        mExpectedEx.expect(AuthorizationException.class);
         mExpectedEx.expectMessage("redirect_uri missing");
         builder.create();
     }
 
     @Test
-    public void testBuilderFailScope() {
+    public void testBuilderFailScope() throws AuthorizationException {
         AuthorizeRequest.Builder builder = new AuthorizeRequest.Builder();
         builder.authorizeEndpoint(mConfig.getDiscoveryUri().toString())
                 .redirectUri(mConfig.getRedirectUri().toString());
-        mExpectedEx.expect(IllegalArgumentException.class);
+        mExpectedEx.expect(AuthorizationException.class);
         mExpectedEx.expectMessage("scope missing");
         builder.create();
     }
 
     @Test
-    public void testBuilder() {
+    public void testBuilder() throws AuthorizationException {
         AuthorizeRequest request = new AuthorizeRequest.Builder()
                 .authorizeEndpoint(mConfig.getDiscoveryUri().toString())
                 .redirectUri(mConfig.getRedirectUri().toString())

--- a/library/src/test/java/com/okta/oidc/net/request/web/LogoutRequestTest.java
+++ b/library/src/test/java/com/okta/oidc/net/request/web/LogoutRequestTest.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import com.okta.oidc.OIDCConfig;
 import com.okta.oidc.net.request.ProviderConfiguration;
 import com.okta.oidc.net.response.TokenResponse;
+import com.okta.oidc.util.AuthorizationException;
 import com.okta.oidc.util.TestValues;
 
 import org.junit.Before;
@@ -46,7 +47,7 @@ public class LogoutRequestTest {
     private ProviderConfiguration mConfiguration;
 
     @Before
-    public void setUp() {
+    public void setUp() throws AuthorizationException {
         mConfig = TestValues.getConfigWithUrl(CUSTOM_URL);
         mConfiguration = TestValues.getProviderConfiguration(CUSTOM_URL);
         mTokenResponse = TokenResponse.RESTORE.restore(TOKEN_RESPONSE);
@@ -60,34 +61,34 @@ public class LogoutRequestTest {
     }
 
     @Test
-    public void testBuilderFailEndpointMissing() {
+    public void testBuilderFailEndpointMissing() throws AuthorizationException {
         LogoutRequest.Builder builder = new LogoutRequest.Builder();
-        mExpectedEx.expect(IllegalArgumentException.class);
+        mExpectedEx.expect(AuthorizationException.class);
         mExpectedEx.expectMessage("end_session_endpoint missing");
         builder.create();
     }
 
     @Test
-    public void testBuilderFailTokenMissing() {
+    public void testBuilderFailTokenMissing() throws AuthorizationException {
         LogoutRequest.Builder builder = new LogoutRequest.Builder();
         builder.endSessionEndpoint(mConfig.getEndSessionRedirectUri().toString());
-        mExpectedEx.expect(IllegalArgumentException.class);
+        mExpectedEx.expect(AuthorizationException.class);
         mExpectedEx.expectMessage("id_token_hint missing");
         builder.create();
     }
 
     @Test
-    public void testBuilderFailRedirectMissing() {
+    public void testBuilderFailRedirectMissing() throws AuthorizationException {
         LogoutRequest.Builder builder = new LogoutRequest.Builder();
         builder.endSessionEndpoint(mConfig.getEndSessionRedirectUri().toString());
         builder.idTokenHint(mTokenResponse.getIdToken());
-        mExpectedEx.expect(IllegalArgumentException.class);
+        mExpectedEx.expect(AuthorizationException.class);
         mExpectedEx.expectMessage("post_logout_redirect_uri missing");
         builder.create();
     }
 
     @Test
-    public void testBuilder() {
+    public void testBuilder() throws AuthorizationException {
         LogoutRequest request = new LogoutRequest.Builder()
                 .state(CUSTOM_STATE)
                 .config(mConfig)

--- a/library/src/test/java/com/okta/oidc/util/TestValues.java
+++ b/library/src/test/java/com/okta/oidc/util/TestValues.java
@@ -20,7 +20,6 @@ import android.text.TextUtils;
 import com.okta.oidc.AuthenticationPayload;
 import com.okta.oidc.OIDCConfig;
 import com.okta.oidc.net.HttpConnection;
-import com.okta.oidc.net.request.HttpRequest;
 import com.okta.oidc.net.request.HttpRequestBuilder;
 import com.okta.oidc.net.request.IntrospectRequest;
 import com.okta.oidc.net.request.NativeAuthorizeRequest;
@@ -147,7 +146,8 @@ public class TestValues {
                 .compact();
     }
 
-    public static AuthorizeRequest getAuthorizeRequest(OIDCConfig config, String verifier) {
+    public static AuthorizeRequest getAuthorizeRequest(OIDCConfig config, String verifier)
+            throws AuthorizationException {
         return new AuthorizeRequest.Builder().codeVerifier(verifier)
                 .authorizeEndpoint(config.getDiscoveryUri().toString())
                 .redirectUri(config.getRedirectUri().toString())
@@ -176,9 +176,9 @@ public class TestValues {
 
     public static TokenRequest getTokenRequest(OIDCConfig config, AuthorizeRequest request,
                                                AuthorizeResponse response, ProviderConfiguration
-                                                       configuration) {
-        return (TokenRequest) HttpRequestBuilder.newRequest()
-                .request(HttpRequest.Type.TOKEN_EXCHANGE)
+                                                       configuration)
+            throws AuthorizationException {
+        return HttpRequestBuilder.newTokenRequest()
                 .authRequest(request)
                 .authResponse(response)
                 .config(config)
@@ -187,9 +187,9 @@ public class TestValues {
     }
 
     public static RefreshTokenRequest getRefreshRequest(OIDCConfig config, TokenResponse response,
-                                                        ProviderConfiguration configuration) {
-        return (RefreshTokenRequest) HttpRequestBuilder.newRequest()
-                .request(HttpRequest.Type.REFRESH_TOKEN)
+                                                        ProviderConfiguration configuration)
+            throws AuthorizationException {
+        return HttpRequestBuilder.newRefreshTokenRequest()
                 .tokenResponse(response)
                 .config(config)
                 .providerConfiguration(configuration)
@@ -197,9 +197,9 @@ public class TestValues {
     }
 
     public static RevokeTokenRequest getRevokeTokenRequest(OIDCConfig config, String tokenToRevoke,
-                                                           ProviderConfiguration configuration) {
-        return (RevokeTokenRequest) HttpRequestBuilder.newRequest()
-                .request(HttpRequest.Type.REVOKE_TOKEN)
+                                                           ProviderConfiguration configuration)
+            throws AuthorizationException {
+        return HttpRequestBuilder.newRevokeTokenRequest()
                 .tokenToRevoke(tokenToRevoke)
                 .providerConfiguration(configuration)
                 .config(config)
@@ -207,9 +207,9 @@ public class TestValues {
     }
 
     public static IntrospectRequest getIntrospectTokenRequest(OIDCConfig config, String token, String tokenType,
-                                                              ProviderConfiguration configuration) {
-        return (IntrospectRequest) HttpRequestBuilder.newRequest()
-                .request(HttpRequest.Type.INTROSPECT)
+                                                              ProviderConfiguration configuration)
+            throws AuthorizationException {
+        return HttpRequestBuilder.newIntrospectRequest()
                 .introspect(token, tokenType)
                 .providerConfiguration(configuration)
                 .config(config)
@@ -217,7 +217,8 @@ public class TestValues {
     }
 
     public static NativeAuthorizeRequest getNativeLogInRequest(OIDCConfig config, String token,
-                                                               ProviderConfiguration configuration) {
+                                                               ProviderConfiguration configuration)
+            throws AuthorizationException {
         return new AuthorizeRequest.Builder()
                 .config(config)
                 .providerConfiguration(configuration)


### PR DESCRIPTION
#### Description:
HttpRequestBuilder.java is used to build all the requests: CONFIGURATION, TOKEN_EXCHANGE, AUTHORIZED, PROFILE, REVOKE_TOKEN, REFRESH_TOKEN, INTROSPECT.
This exposes some unused parameters depending on the request. For example if building a CONFIGURATION request you can add a token to the parameter. This change adds a base builder
with common parameters and other requests extends it.

#### Testing details:
- [x]  Verified basic functionality of change
- [x]  Added tests 

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes

##### RESOLVES: 
[OKTA-218147](https://oktainc.atlassian.net/browse/OKTA-218147)

#### Primary Reviewer(s):
@sergiymokiyenko-okta 
@ihormartsekha-okta 
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

