### PR TITLE
Update gradle to 3.4.1 and add @hide annotation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'org.owasp:dependency-check-gradle:4.0.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/config/checkstyle/suppression.xml
+++ b/config/checkstyle/suppression.xml
@@ -29,9 +29,7 @@
     <suppress checks="Javadoc" files="OktaRepository\.java" />
     <suppress checks="Javadoc" files="Persistable\.java" />
     <suppress checks="Javadoc" files="AuthClientFactoryImpl\.java" />
-    <suppress checks="Javadoc" files="SyncWebAuthClientFactory\.java" />
     <suppress checks="Javadoc" files="BaseAuth\.java" />
-    <suppress checks="Javadoc" files="SyncAuthClientFactory\.java" />
     <suppress checks="Javadoc" files="SyncSessionClientFactory\.java" />
     <suppress checks="Javadoc" files="SessionClientFactoryImpl\.java" />
     <suppress checks="Javadoc" files="SyncSessionClientFactoryImpl\.java" />

--- a/library/src/main/java/com/okta/oidc/OktaResultFragment.java
+++ b/library/src/main/java/com/okta/oidc/OktaResultFragment.java
@@ -34,6 +34,9 @@ import org.json.JSONException;
 import static android.app.Activity.RESULT_CANCELED;
 import static com.okta.oidc.OktaAuthenticationActivity.EXTRA_EXCEPTION;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class OktaResultFragment extends Fragment {
     static final String AUTHENTICATION_REQUEST = "authRequest";

--- a/library/src/main/java/com/okta/oidc/OktaState.java
+++ b/library/src/main/java/com/okta/oidc/OktaState.java
@@ -26,6 +26,9 @@ import com.okta.oidc.storage.Persistable;
 
 import static com.okta.oidc.clients.State.IDLE;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class OktaState {
     private OktaRepository mOktaRepo;

--- a/library/src/main/java/com/okta/oidc/RequestDispatcher.java
+++ b/library/src/main/java/com/okta/oidc/RequestDispatcher.java
@@ -34,6 +34,8 @@ import java.util.concurrent.TimeUnit;
 import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 
 /**
+ * @hide
+ *
  * Executor Service that runs tasks on worker thread
  * call back on ui thread or specified executor.
  */

--- a/library/src/main/java/com/okta/oidc/State.java
+++ b/library/src/main/java/com/okta/oidc/State.java
@@ -17,6 +17,9 @@ package com.okta.oidc;
 
 import androidx.annotation.RestrictTo;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public enum State {
     IDLE,

--- a/library/src/main/java/com/okta/oidc/clients/AuthAPI.java
+++ b/library/src/main/java/com/okta/oidc/clients/AuthAPI.java
@@ -41,6 +41,8 @@ import static com.okta.oidc.clients.State.IDLE;
 import static com.okta.oidc.util.AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW;
 
 /**
+ * @hide
+ *
  * This is a helper for authentication. It contains the APIs for getting
  * the provider configuration, validating results, and code exchange.
  */

--- a/library/src/main/java/com/okta/oidc/clients/AuthClientFactoryImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/AuthClientFactoryImpl.java
@@ -27,6 +27,9 @@ import com.okta.oidc.storage.security.EncryptionManager;
 
 import java.util.concurrent.Executor;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class AuthClientFactoryImpl implements ClientFactory<AuthClient> {
     private Executor mCallbackExecutor;

--- a/library/src/main/java/com/okta/oidc/clients/State.java
+++ b/library/src/main/java/com/okta/oidc/clients/State.java
@@ -17,6 +17,9 @@ package com.okta.oidc.clients;
 
 import androidx.annotation.RestrictTo;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public enum State {
     IDLE,

--- a/library/src/main/java/com/okta/oidc/clients/SyncAuthClientFactory.java
+++ b/library/src/main/java/com/okta/oidc/clients/SyncAuthClientFactory.java
@@ -22,6 +22,9 @@ import com.okta.oidc.net.HttpConnectionFactory;
 import com.okta.oidc.storage.OktaStorage;
 import com.okta.oidc.storage.security.EncryptionManager;
 
+/**
+ * Used to create a synchronous authentication client.
+ */
 public class SyncAuthClientFactory implements ClientFactory<SyncAuthClient> {
     @Override
     public SyncAuthClientImpl createClient(OIDCConfig oidcConfig,

--- a/library/src/main/java/com/okta/oidc/clients/sessions/SessionClientFactoryImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/sessions/SessionClientFactoryImpl.java
@@ -19,6 +19,9 @@ import androidx.annotation.RestrictTo;
 
 import java.util.concurrent.Executor;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class SessionClientFactoryImpl {
     private Executor executor;

--- a/library/src/main/java/com/okta/oidc/clients/sessions/SyncSessionClientFactoryImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/sessions/SyncSessionClientFactoryImpl.java
@@ -21,6 +21,9 @@ import com.okta.oidc.OIDCConfig;
 import com.okta.oidc.OktaState;
 import com.okta.oidc.net.HttpConnectionFactory;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class SyncSessionClientFactoryImpl {
     public SyncSessionClient createClient(OIDCConfig oidcConfig, OktaState oktaState,

--- a/library/src/main/java/com/okta/oidc/clients/web/WebAuthClientFactory.java
+++ b/library/src/main/java/com/okta/oidc/clients/web/WebAuthClientFactory.java
@@ -29,6 +29,9 @@ import com.okta.oidc.storage.security.EncryptionManager;
 
 import java.util.concurrent.Executor;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class WebAuthClientFactory implements ClientFactory<WebAuthClient> {
     private Executor mCallbackExecutor;

--- a/library/src/main/java/com/okta/oidc/net/HttpConnection.java
+++ b/library/src/main/java/com/okta/oidc/net/HttpConnection.java
@@ -43,6 +43,9 @@ import javax.net.ssl.HttpsURLConnection;
 
 import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 
+/**
+ * @hide
+ */
 @RestrictTo(LIBRARY_GROUP)
 public class HttpConnection {
     private static final int DEFAULT_CONNECTION_TIMEOUT_MS = 15000; //15s

--- a/library/src/main/java/com/okta/oidc/net/HttpResponse.java
+++ b/library/src/main/java/com/okta/oidc/net/HttpResponse.java
@@ -31,6 +31,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public final class HttpResponse {
     private final int mStatusCode;

--- a/library/src/main/java/com/okta/oidc/net/request/AuthorizedRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/AuthorizedRequest.java
@@ -28,6 +28,9 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class AuthorizedRequest extends BaseRequest<JSONObject, AuthorizationException> {
 

--- a/library/src/main/java/com/okta/oidc/net/request/BaseRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/BaseRequest.java
@@ -30,6 +30,9 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public abstract class BaseRequest<T, U extends AuthorizationException>
         implements HttpRequest<T, U> {

--- a/library/src/main/java/com/okta/oidc/net/request/ConfigurationRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/ConfigurationRequest.java
@@ -30,6 +30,9 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public final class ConfigurationRequest extends
         BaseRequest<ProviderConfiguration, AuthorizationException> {

--- a/library/src/main/java/com/okta/oidc/net/request/HttpRequestBuilder.java
+++ b/library/src/main/java/com/okta/oidc/net/request/HttpRequestBuilder.java
@@ -31,6 +31,9 @@ import com.okta.oidc.util.AuthorizationException;
 
 import java.util.Map;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class HttpRequestBuilder {
 

--- a/library/src/main/java/com/okta/oidc/net/request/IntrospectRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/IntrospectRequest.java
@@ -32,6 +32,9 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class IntrospectRequest extends
         BaseRequest<IntrospectInfo, AuthorizationException> {

--- a/library/src/main/java/com/okta/oidc/net/request/NativeAuthorizeRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/NativeAuthorizeRequest.java
@@ -31,6 +31,9 @@ import com.okta.oidc.util.AuthorizationException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class NativeAuthorizeRequest extends BaseRequest<AuthorizeResponse, AuthorizationException> {
     private Parameters mParameters;

--- a/library/src/main/java/com/okta/oidc/net/request/ProviderConfiguration.java
+++ b/library/src/main/java/com/okta/oidc/net/request/ProviderConfiguration.java
@@ -25,6 +25,9 @@ import androidx.annotation.VisibleForTesting;
 import com.google.gson.Gson;
 import com.okta.oidc.storage.Persistable;
 
+/**
+ * @hide
+ */
 @SuppressWarnings("unused")
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class ProviderConfiguration implements Persistable {

--- a/library/src/main/java/com/okta/oidc/net/request/RefreshTokenRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/RefreshTokenRequest.java
@@ -26,6 +26,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class RefreshTokenRequest extends TokenRequest {
     RefreshTokenRequest(HttpRequestBuilder.RefreshToken b) {

--- a/library/src/main/java/com/okta/oidc/net/request/RevokeTokenRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/RevokeTokenRequest.java
@@ -28,6 +28,9 @@ import com.okta.oidc.util.AuthorizationException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class RevokeTokenRequest extends BaseRequest<Boolean, AuthorizationException> {
     RevokeTokenRequest(HttpRequestBuilder.RevokeToken b) {

--- a/library/src/main/java/com/okta/oidc/net/request/TLSSocketFactory.java
+++ b/library/src/main/java/com/okta/oidc/net/request/TLSSocketFactory.java
@@ -28,6 +28,8 @@ import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
+ * @hide
+ *
  * SSLSocketFactory which wraps default SSLSocketFactory and enable TLS v1.1, v1.2.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY)

--- a/library/src/main/java/com/okta/oidc/net/request/TokenRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/TokenRequest.java
@@ -40,6 +40,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @hide
+ */
 @SuppressWarnings({"FieldCanBeLocal", "unused"})
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class TokenRequest extends BaseRequest<TokenResponse, AuthorizationException> {

--- a/library/src/main/java/com/okta/oidc/net/request/web/AuthorizeRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/web/AuthorizeRequest.java
@@ -37,6 +37,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @hide
+ */
 //https://developer.okta.com/docs/api/resources/oidc#authorize
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 @SuppressWarnings("unused")

--- a/library/src/main/java/com/okta/oidc/net/request/web/LogoutRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/web/LogoutRequest.java
@@ -29,6 +29,9 @@ import com.okta.oidc.net.response.TokenResponse;
 import com.okta.oidc.util.AuthorizationException;
 import com.okta.oidc.util.CodeVerifierUtil;
 
+/**
+ * @hide
+ */
 //https://developer.okta.com/docs/api/resources/oidc#logout
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class LogoutRequest extends WebRequest {

--- a/library/src/main/java/com/okta/oidc/net/request/web/WebRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/web/WebRequest.java
@@ -24,6 +24,9 @@ import androidx.annotation.RestrictTo;
 import com.google.gson.Gson;
 import com.okta.oidc.storage.Persistable;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public abstract class WebRequest implements Persistable {
     @NonNull

--- a/library/src/main/java/com/okta/oidc/net/response/TokenResponse.java
+++ b/library/src/main/java/com/okta/oidc/net/response/TokenResponse.java
@@ -22,6 +22,9 @@ import androidx.annotation.RestrictTo;
 import com.google.gson.Gson;
 import com.okta.oidc.storage.Persistable;
 
+/**
+ * @hide
+ */
 @SuppressWarnings("unused")
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class TokenResponse implements Persistable {

--- a/library/src/main/java/com/okta/oidc/net/response/web/AuthorizeResponse.java
+++ b/library/src/main/java/com/okta/oidc/net/response/web/AuthorizeResponse.java
@@ -22,6 +22,9 @@ import androidx.annotation.RestrictTo;
 
 import com.google.gson.Gson;
 
+/**
+ * @hide
+ */
 //https://developer.okta.com/docs/api/resources/oidc#response-properties
 @SuppressWarnings({"unused", "FieldCanBeLocal"})
 @RestrictTo(RestrictTo.Scope.LIBRARY)

--- a/library/src/main/java/com/okta/oidc/net/response/web/LogoutResponse.java
+++ b/library/src/main/java/com/okta/oidc/net/response/web/LogoutResponse.java
@@ -22,6 +22,9 @@ import androidx.annotation.RestrictTo;
 
 import com.google.gson.Gson;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class LogoutResponse extends WebResponse {
     private String state;

--- a/library/src/main/java/com/okta/oidc/net/response/web/WebResponse.java
+++ b/library/src/main/java/com/okta/oidc/net/response/web/WebResponse.java
@@ -22,6 +22,9 @@ import androidx.annotation.RestrictTo;
 import com.google.gson.Gson;
 import com.okta.oidc.storage.Persistable;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public abstract class WebResponse implements Persistable {
 

--- a/library/src/main/java/com/okta/oidc/storage/OktaRepository.java
+++ b/library/src/main/java/com/okta/oidc/storage/OktaRepository.java
@@ -31,6 +31,9 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class OktaRepository {
     private static final String TAG = OktaRepository.class.getSimpleName();

--- a/library/src/main/java/com/okta/oidc/storage/Persistable.java
+++ b/library/src/main/java/com/okta/oidc/storage/Persistable.java
@@ -19,6 +19,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 
+/**
+ * @hide
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public interface Persistable {
     @NonNull


### PR DESCRIPTION
#### Description:
This prevents javadocs from being created for classes
that are restricted to library. Javadocs are generated
using doclava

#### Testing details:
- [x]  Verified basic functionality of change
- [ ]  Added tests 

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes

##### RESOLVES: 
[OKTA-215668](https://oktainc.atlassian.net/browse/OKTA-215668)

#### Primary Reviewer(s):
@sergiymokiyenko-okta 
@ihormartsekha-okta 
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

