### PR TITLE
Fix bug when switching between encryption managers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,9 +20,11 @@ android {
             properties.load(project.rootProject.file('local.properties').newDataInputStream())
             def username = properties.getProperty('test.username')
             def password = properties.getProperty('test.password')
+            def pincode = properties.getProperty('test.pincode')
             if (username != null && password != null) {
                 buildConfigField "String", "USERNAME", username
                 buildConfigField "String", "PASSWORD", password
+                buildConfigField "String", "PINCODE", pincode
             }
         }
 

--- a/app/src/main/res/layout/plain_activity.xml
+++ b/app/src/main/res/layout/plain_activity.xml
@@ -20,6 +20,12 @@
             android:paddingRight="@dimen/activity_horizontal_margin"
             android:paddingBottom="@dimen/activity_vertical_margin">
 
+            <CheckBox
+                android:id="@+id/biometric"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/use_biometrics" />
+
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="account_id_description">The Username is optional. If specified, it is transmitted as a login_hint parameter in the authorization request.</string>
     <string name="auth_options">Authorization options:</string>
     <string name="oidc">OIDC</string>
+    <string name="use_biometrics">Use biometrics</string>
 </resources>

--- a/library/src/main/java/com/okta/oidc/storage/security/BaseEncryptionManager.java
+++ b/library/src/main/java/com/okta/oidc/storage/security/BaseEncryptionManager.java
@@ -87,6 +87,24 @@ abstract class BaseEncryptionManager implements EncryptionManager {
             throw new RuntimeException("Failed initialize KeyStore", e.getCause());
         }
 
+        generateKeys(context);
+
+        // Init Cipher
+        if (initCipher) {
+            try {
+                mCipher = createCipher(mTransformationString);
+                if (mCipher == null) {
+                    throw new RuntimeException("Cipher is null");
+                }
+            } catch (GeneralSecurityException e) {
+                throw new RuntimeException("Failed initialize Cipher", e.getCause());
+            }
+        }
+
+        return true;
+    }
+
+    private void generateKeys(Context context) {
         // Check if exist instead generate new private and public keys
         try {
             if (!mKeyStore.containsAlias(mKeyAlias)) {
@@ -122,20 +140,6 @@ abstract class BaseEncryptionManager implements EncryptionManager {
         } catch (KeyStoreException e) {
             throw new RuntimeException("Keystore exception.", e.getCause());
         }
-
-        // Init Cipher
-        if (initCipher) {
-            try {
-                mCipher = createCipher(mTransformationString);
-                if (mCipher == null) {
-                    throw new RuntimeException("Cipher is null");
-                }
-            } catch (GeneralSecurityException e) {
-                throw new RuntimeException("Failed initialize Cipher", e.getCause());
-            }
-        }
-
-        return true;
     }
 
     private KeyStore createKeyStore() throws GeneralSecurityException, IOException {
@@ -320,6 +324,11 @@ abstract class BaseEncryptionManager implements EncryptionManager {
     @Override
     public void removeKeys() {
         deleteInvalidKey(mKeyAlias);
+    }
+
+    @Override
+    public void recreateKeys(Context context) {
+        prepare(context, false);
     }
 
     @Override

--- a/library/src/main/java/com/okta/oidc/storage/security/DefaultEncryptionManager.java
+++ b/library/src/main/java/com/okta/oidc/storage/security/DefaultEncryptionManager.java
@@ -88,6 +88,11 @@ public class DefaultEncryptionManager implements EncryptionManager {
     }
 
     @Override
+    public void recreateKeys(Context context) {
+        mEncryptionManager.recreateKeys(context);
+    }
+
+    @Override
     public boolean isValidKeys() {
         return mEncryptionManager.isValidKeys();
     }

--- a/library/src/main/java/com/okta/oidc/storage/security/EncryptionManager.java
+++ b/library/src/main/java/com/okta/oidc/storage/security/EncryptionManager.java
@@ -15,6 +15,8 @@
 
 package com.okta.oidc.storage.security;
 
+import android.content.Context;
+
 import com.okta.oidc.storage.OktaStorage;
 
 import java.io.UnsupportedEncodingException;
@@ -88,6 +90,11 @@ public interface EncryptionManager {
      * remove current keys.
      */
     void removeKeys();
+
+    /**
+     * recreate keys.
+     */
+    void recreateKeys(Context context);
 
     /**
      * if user authenticated and cipher is valid to use private key.

--- a/library/src/main/java/com/okta/oidc/storage/security/EncryptionManagerAPI23.java
+++ b/library/src/main/java/com/okta/oidc/storage/security/EncryptionManagerAPI23.java
@@ -158,6 +158,9 @@ class EncryptionManagerAPI23 extends BaseEncryptionManager {
         try {
             Cipher cipher = createCipher(mTransformationString);
             PrivateKey key = (PrivateKey) mKeyStore.getKey(mKeyAlias, null);
+            if (key == null) {
+                return false;
+            }
             try {
                 KeyFactory factory = KeyFactory.getInstance(key.getAlgorithm(), mKeyStoreName);
                 KeyInfo keyInfo = factory.getKeySpec(key, KeyInfo.class);

--- a/library/src/main/java/com/okta/oidc/storage/security/GuardedEncryptionManager.java
+++ b/library/src/main/java/com/okta/oidc/storage/security/GuardedEncryptionManager.java
@@ -119,6 +119,11 @@ public class GuardedEncryptionManager implements EncryptionManager {
     }
 
     @Override
+    public void recreateKeys(Context context) {
+        mEncryptionManager.recreateKeys(context);
+    }
+
+    @Override
     public boolean isValidKeys() {
         return mEncryptionManager.isValidKeys();
     }

--- a/library/src/test/java/com/okta/oidc/util/EncryptionManagerStub.java
+++ b/library/src/test/java/com/okta/oidc/util/EncryptionManagerStub.java
@@ -1,5 +1,7 @@
 package com.okta.oidc.util;
 
+import android.content.Context;
+
 import com.okta.oidc.storage.security.EncryptionManager;
 
 import java.io.UnsupportedEncodingException;
@@ -82,6 +84,11 @@ public class EncryptionManagerStub implements EncryptionManager {
 
     @Override
     public void removeKeys() {
+
+    }
+
+    @Override
+    public void recreateKeys(Context context) {
 
     }
 


### PR DESCRIPTION
#### Description:
Bug was caused by removing keys and reusing the same
encryption manager object. The keys need to be recreated.

Add sample to show how to combine the encryption manager
with the keyguard. This will require the user to authenticate
the device before any profile or token calls could be done.
Espresso test added.

#### Testing details:
- [x]  Verified basic functionality of change
- [x]  Added tests 

##### RESOLVES: 
[OKTA-239612](https://oktainc.atlassian.net/browse/OKTA-239612)
