### PR TITLE
add sign out convience api

### DIFF
--- a/app/src/androidTest/java/com/okta/oidc/example/PlainActivityTest.java
+++ b/app/src/androidTest/java/com/okta/oidc/example/PlainActivityTest.java
@@ -59,6 +59,7 @@ import static com.okta.oidc.example.Utils.USERNAME;
 import static com.okta.oidc.example.Utils.acceptChromePrivacyOption;
 import static com.okta.oidc.example.Utils.customTabInteraction;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -133,7 +134,7 @@ public class PlainActivityTest {
 
         mDevice.wait(Until.findObject(By.pkg(SAMPLE_APP)), TRANSITION_TIMEOUT);
         assertNotNull(activityRule.getActivity().mSessionClient.getTokens());
-        onView(withId(R.id.sign_out)).check(matches(isDisplayed()));
+        onView(withId(R.id.sign_out_of_okta)).check(matches(isDisplayed()));
     }
 
     @Test
@@ -215,8 +216,8 @@ public class PlainActivityTest {
     @Test
     public void test9_signOutOfOkta() {
         signInIfNotAlready();
-        onView(withId(R.id.sign_out)).check(matches(isDisplayed()));
-        onView(withId(R.id.sign_out)).perform(click());
+        onView(withId(R.id.sign_out_of_okta)).check(matches(isDisplayed()));
+        onView(withId(R.id.sign_out_of_okta)).perform(click());
 
         mDevice.wait(Until.findObject(By.pkg(CHROME_STABLE)), TRANSITION_TIMEOUT);
         mDevice.wait(Until.findObject(By.pkg(SAMPLE_APP)), TRANSITION_TIMEOUT);
@@ -243,7 +244,7 @@ public class PlainActivityTest {
     @Test
     public void testB_signInWithPayload() throws UiObjectNotFoundException {
         activityRule.getActivity().mPayload = new AuthenticationPayload.Builder()
-                .setLoginHint("devex@okta.com")
+                .setLoginHint(BuildConfig.USERNAME)
                 .addParameter("max_age", "5000")
                 .build();
 
@@ -322,6 +323,17 @@ public class PlainActivityTest {
         onView(withId(R.id.check_expired)).perform(click());
         onView(withId(R.id.status))
                 .check(matches(withText(containsString("token not expired"))));
+    }
+
+    @Test
+    public void testG_signOut() {
+        signInIfNotAlready();
+        onView(withId(R.id.sign_out)).check(matches(isDisplayed()));
+        onView(withId(R.id.sign_out)).perform(click());
+
+        mDevice.wait(Until.findObject(By.pkg(CHROME_STABLE)), TRANSITION_TIMEOUT);
+        mDevice.wait(Until.findObject(By.pkg(SAMPLE_APP)), TRANSITION_TIMEOUT);
+        onView(withId(R.id.sign_in));
     }
 
     @Test

--- a/app/src/androidTest/java/com/okta/oidc/example/SampleActivityTest.java
+++ b/app/src/androidTest/java/com/okta/oidc/example/SampleActivityTest.java
@@ -247,7 +247,7 @@ public class SampleActivityTest {
     @Test
     public void testB_signInWithPayload() throws UiObjectNotFoundException {
         activityRule.getActivity().mPayload = new AuthenticationPayload.Builder()
-                .setLoginHint("devex@okta.com")
+                .setLoginHint(BuildConfig.USERNAME)
                 .addParameter("max_age", "5000")
                 .build();
 

--- a/app/src/main/res/layout/plain_activity.xml
+++ b/app/src/main/res/layout/plain_activity.xml
@@ -56,10 +56,18 @@
                     tools:ignore="HardcodedText" />
 
                 <Button
+                    android:id="@+id/sign_out_of_okta"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Sign out of Okta"
+                    android:visibility="gone"
+                    tools:ignore="HardcodedText" />
+
+                <Button
                     android:id="@+id/sign_out"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Sign out from Okta"
+                    android:text="Sign out"
                     android:visibility="gone"
                     tools:ignore="HardcodedText" />
 

--- a/library/src/main/java/com/okta/oidc/RequestCallback.java
+++ b/library/src/main/java/com/okta/oidc/RequestCallback.java
@@ -19,7 +19,7 @@ import androidx.annotation.NonNull;
 
 /**
  * Callback for a authorize request that does not use the Chrome custom tabs as a user agent.
- * Requests such as getting provider configuration, user profiles, token requests.
+ * Requests such as getting provider configuration, user profiles, token requests, sign out.
  *
  * @param <T> the type this request will return on authorized.
  * @param <U> the {@link com.okta.oidc.util.AuthorizationException} type of exception in error

--- a/library/src/main/java/com/okta/oidc/clients/AuthAPI.java
+++ b/library/src/main/java/com/okta/oidc/clients/AuthAPI.java
@@ -17,6 +17,7 @@ package com.okta.oidc.clients;
 
 import android.content.Context;
 import android.text.TextUtils;
+import android.util.Log;
 
 import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
@@ -24,6 +25,8 @@ import androidx.annotation.WorkerThread;
 
 import com.okta.oidc.OIDCConfig;
 import com.okta.oidc.OktaState;
+import com.okta.oidc.Tokens;
+import com.okta.oidc.clients.sessions.SyncSessionClient;
 import com.okta.oidc.net.OktaHttpClient;
 import com.okta.oidc.net.request.BaseRequest;
 import com.okta.oidc.net.request.ConfigurationRequest;
@@ -44,8 +47,18 @@ import java.lang.ref.WeakReference;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static androidx.annotation.RestrictTo.Scope.TESTS;
+
+import static com.okta.oidc.clients.BaseAuth.FAILED_CLEAR_DATA;
+import static com.okta.oidc.clients.BaseAuth.FAILED_REVOKE_ACCESS_TOKEN;
+import static com.okta.oidc.clients.BaseAuth.FAILED_REVOKE_REFRESH_TOKEN;
+import static com.okta.oidc.clients.BaseAuth.REMOVE_TOKENS;
+import static com.okta.oidc.clients.BaseAuth.REVOKE_ACCESS_TOKEN;
+import static com.okta.oidc.clients.BaseAuth.REVOKE_REFRESH_TOKEN;
+import static com.okta.oidc.clients.BaseAuth.TOKEN_DECRYPT;
 import static com.okta.oidc.clients.State.IDLE;
 import static com.okta.oidc.util.AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW;
+import static com.okta.oidc.util.AuthorizationException.TYPE_ENCRYPTION_ERROR;
 
 /**
  * @hide This is a helper for authentication. It contains the APIs for getting
@@ -53,9 +66,12 @@ import static com.okta.oidc.util.AuthorizationException.GeneralErrors.USER_CANCE
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class AuthAPI {
+    private static final String TAG = "AuthClientImpl";
     protected OktaState mOktaState;
     protected OIDCConfig mOidcConfig;
     protected OktaHttpClient mHttpClient;
+    protected int mSignOutFlags;
+    protected int mSignOutStatus;
 
     protected AtomicBoolean mCancel = new AtomicBoolean();
     protected AtomicReference<WeakReference<BaseRequest>> mCurrentRequest =
@@ -155,13 +171,65 @@ public class AuthAPI {
     }
 
     /*
-     * Since sign-in is a collection of network ops. This method is used to check after each
-     * network call if cancel was called. So even if the previous network call was successful
-     * this check will stop further progress.
+     * Since sign-in/revokeTokens is a collection of network ops. This method is used to check
+     * after each network call if cancel was called. So even if the previous network call was
+     * successful this check will stop further progress.
      */
     protected void checkIfCanceled() throws IOException {
         if (mCancel.get()) {
             throw new IOException("Canceled");
         }
+    }
+
+    private int revoke(SyncSessionClient client, int tokenType) {
+        try {
+            Tokens tokens = client.getTokens();
+            if (tokens != null) {
+                client.revokeToken(tokenType == REVOKE_ACCESS_TOKEN ? tokens.getAccessToken()
+                        : tokens.getRefreshToken());
+            }
+            return 0;
+        } catch (AuthorizationException e) {
+            Log.w(TAG, "Revoke token failure", e);
+            int status = tokenType == REVOKE_ACCESS_TOKEN ? FAILED_REVOKE_ACCESS_TOKEN
+                    : FAILED_REVOKE_REFRESH_TOKEN;
+            if (e.type == TYPE_ENCRYPTION_ERROR) {
+                status |= TOKEN_DECRYPT;
+            }
+            return status;
+        }
+    }
+
+    protected void removeTokens(SyncSessionClient client) {
+        if ((mSignOutFlags & REMOVE_TOKENS) == REMOVE_TOKENS) {
+            if ((mSignOutStatus & FAILED_REVOKE_REFRESH_TOKEN) == 0 &&
+                    (mSignOutStatus & FAILED_REVOKE_ACCESS_TOKEN) == 0) {
+                client.clear();
+            } else {
+                mSignOutStatus |= FAILED_CLEAR_DATA;
+            }
+        }
+    }
+
+    protected void revokeTokens(SyncSessionClient client) throws IOException {
+        if ((mSignOutFlags & REVOKE_ACCESS_TOKEN) == REVOKE_ACCESS_TOKEN) {
+            mSignOutStatus |= revoke(client, REVOKE_ACCESS_TOKEN);
+        }
+        checkIfCanceled();
+
+        if ((mSignOutFlags & REVOKE_REFRESH_TOKEN) == REVOKE_REFRESH_TOKEN) {
+            mSignOutStatus |= revoke(client, REVOKE_REFRESH_TOKEN);
+        }
+        checkIfCanceled();
+    }
+
+    @RestrictTo(TESTS)
+    public int getSignOutFlags() {
+        return mSignOutFlags;
+    }
+
+    @RestrictTo(TESTS)
+    public int getSignOutStatus() {
+        return mSignOutStatus;
     }
 }

--- a/library/src/main/java/com/okta/oidc/clients/AuthClient.java
+++ b/library/src/main/java/com/okta/oidc/clients/AuthClient.java
@@ -17,6 +17,7 @@ package com.okta.oidc.clients;
 
 import com.okta.oidc.AuthenticationPayload;
 import com.okta.oidc.RequestCallback;
+import com.okta.oidc.ResultCallback;
 import com.okta.oidc.clients.sessions.SessionClient;
 import com.okta.oidc.results.Result;
 import com.okta.oidc.storage.security.EncryptionManager;
@@ -60,4 +61,39 @@ public interface AuthClient extends BaseAuth<SessionClient> {
      * @throws AuthorizationException exception if migration fails.
      */
     void migrateTo(EncryptionManager manager) throws AuthorizationException;
+
+    /**
+     * Convenience method to completely sign out of application.
+     * Performs the following operations in order:
+     * 1. Revokes the access_token. If this fails step 3 will not be attempted.
+     * 2. Revokes the refresh_token. If this fails step 3 will not be attempted.
+     * 3. Removes all persistence data. Only if steps 1 & 2 succeeds.
+     *
+     * @param resultCallback the callback containing the bitwise status. AuthorizationException may
+     *                       be null.
+     * @see #SUCCESS
+     * @see #FAILED_REVOKE_ACCESS_TOKEN
+     * @see #FAILED_REVOKE_REFRESH_TOKEN
+     * @see #FAILED_CLEAR_DATA
+     */
+    void signOut(ResultCallback<Integer, AuthorizationException> resultCallback);
+
+    /**
+     * Convenience method to completely sign out of application.
+     * Performs the following depending on the flags parameter:
+     * {@link #REVOKE_ACCESS_TOKEN} Perform revoke access_token operation.
+     * {@link #REVOKE_REFRESH_TOKEN} Perform revoke the refresh_token operation.
+     * {@link #REMOVE_TOKENS} Removes all persistent data. Attempted only if revoke tokens succeeds
+     * or no flag is set to revoke tokens.
+     * {@link #ALL} All of the above flags. Same as calling {@link #signOut}
+     *
+     * @param flags          the flag for the operations to perform.
+     * @param resultCallback the callback containing the bitwise status. AuthorizationException may
+     *                       be null.
+     * @see #SUCCESS
+     * @see #FAILED_REVOKE_ACCESS_TOKEN
+     * @see #FAILED_REVOKE_REFRESH_TOKEN
+     * @see #FAILED_CLEAR_DATA
+     */
+    void signOut(int flags, ResultCallback<Integer, AuthorizationException> resultCallback);
 }

--- a/library/src/main/java/com/okta/oidc/clients/AuthClientImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/AuthClientImpl.java
@@ -24,6 +24,7 @@ import com.okta.oidc.AuthenticationPayload;
 import com.okta.oidc.OIDCConfig;
 import com.okta.oidc.RequestCallback;
 import com.okta.oidc.RequestDispatcher;
+import com.okta.oidc.ResultCallback;
 import com.okta.oidc.clients.sessions.SessionClient;
 import com.okta.oidc.clients.sessions.SessionClientFactoryImpl;
 import com.okta.oidc.net.OktaHttpClient;
@@ -99,6 +100,23 @@ class AuthClientImpl implements AuthClient {
     @Override
     public SessionClient getSessionClient() {
         return mSessionImpl;
+    }
+
+    @Override
+    public void signOut(ResultCallback<Integer, AuthorizationException> callback) {
+        signOut(ALL, callback);
+    }
+
+    @Override
+    public void signOut(int flags, ResultCallback<Integer, AuthorizationException> callback) {
+        mFutureTask = mDispatcher.submit(() -> {
+            final int status = mSyncNativeAuthClient.signOut(flags);
+            mDispatcher.submitResults(() -> {
+                if (callback != null) {
+                    callback.onSuccess(status);
+                }
+            });
+        });
     }
 
     private void cancelFuture() {

--- a/library/src/main/java/com/okta/oidc/clients/BaseAuth.java
+++ b/library/src/main/java/com/okta/oidc/clients/BaseAuth.java
@@ -21,6 +21,61 @@ package com.okta.oidc.clients;
  * @param <S> the generic type of session client
  */
 public interface BaseAuth<S> {
+
+    /**
+     * When set, signing out will attempt to revoke the access token.
+     */
+    int REVOKE_ACCESS_TOKEN = 0x00000001;
+    /**
+     * When set, signing out will attempt to revoke the refresh token.
+     */
+    int REVOKE_REFRESH_TOKEN = 0x00000002;
+    /**
+     * When set, signing out will attempt to remove tokens from persistent storage.
+     */
+    int REMOVE_TOKENS = 0x00000004;
+    /**
+     * When set, revokeTokens will attempt to clear the browser session. Only applicable
+     * for {@link com.okta.oidc.clients.web.WebAuthClient}
+     */
+    int SIGN_OUT_SESSION = 0x00000008;
+    /**
+     * Internal use only. For performing all operations.
+     */
+    int ALL = SIGN_OUT_SESSION | REVOKE_ACCESS_TOKEN | REVOKE_REFRESH_TOKEN | REMOVE_TOKENS;
+
+    /**
+     * Status returned when sign out steps have all completed.
+     */
+    int SUCCESS = 0x00000000;
+    /**
+     * Bitwise status returned when clearing browser failed.
+     */
+    int FAILED_CLEAR_SESSION = SIGN_OUT_SESSION;
+    /**
+     * Bitwise status returned when revoking access token failed.
+     */
+    int FAILED_REVOKE_ACCESS_TOKEN = REVOKE_ACCESS_TOKEN;
+    /**
+     * Bitwise status returned when revoking refresh token failed.
+     */
+    int FAILED_REVOKE_REFRESH_TOKEN = REVOKE_REFRESH_TOKEN;
+    /**
+     * Bitwise status returned when clearing data failed.
+     */
+    int FAILED_CLEAR_DATA = REMOVE_TOKENS;
+    /**
+     * Bitwise status returned when retrieving token failed due to a encryption error.
+     * Device needs to be authenticated.
+     */
+    int TOKEN_DECRYPT = 0x00000010;
+
+    /**
+     * Internal use only. Initial status is all ops have failed.
+     */
+    int FAILED_ALL = FAILED_CLEAR_SESSION | FAILED_REVOKE_ACCESS_TOKEN |
+            FAILED_REVOKE_REFRESH_TOKEN | FAILED_CLEAR_DATA;
+
     /**
      * Gets session client.
      *

--- a/library/src/main/java/com/okta/oidc/clients/SyncAuthClient.java
+++ b/library/src/main/java/com/okta/oidc/clients/SyncAuthClient.java
@@ -59,4 +59,37 @@ public interface SyncAuthClient extends BaseAuth<SyncSessionClient> {
      * @throws AuthorizationException exception if migration fails.
      */
     void migrateTo(EncryptionManager manager) throws AuthorizationException;
+
+    /**
+     * Convenience method to completely sign out of application.
+     * Performs the following operations in order:
+     * 1. Revokes the access_token. If this fails step 3 will not be attempted.
+     * 2. Revokes the refresh_token. If this fails step 3 will not be attempted.
+     * 3. Removes all persistence data. Only if steps 1 & 2 succeeds.
+     *
+     * @return the bitwise status.
+     * @see #SUCCESS
+     * @see #FAILED_REVOKE_ACCESS_TOKEN
+     * @see #FAILED_REVOKE_REFRESH_TOKEN
+     * @see #FAILED_CLEAR_DATA
+     */
+    int signOut();
+
+    /**
+     * Convenience method to completely sign out of application.
+     * Performs the following depending on the flags parameter:
+     * {@link #REVOKE_ACCESS_TOKEN} Perform revoke access_token operation.
+     * {@link #REVOKE_REFRESH_TOKEN} Perform revoke the refresh_token operation.
+     * {@link #REMOVE_TOKENS} Removes all persistent data. Attempted only if revoke tokens succeeds
+     * or no flag is set to revoke tokens.
+     * {@link #ALL} All of the above flags. Same as calling {@link #signOut}
+     *
+     * @param flags the flag for the operations to perform.
+     * @return the bitwise status.
+     * @see #SUCCESS
+     * @see #FAILED_REVOKE_ACCESS_TOKEN
+     * @see #FAILED_REVOKE_REFRESH_TOKEN
+     * @see #FAILED_CLEAR_DATA
+     */
+    int signOut(int flags);
 }

--- a/library/src/main/java/com/okta/oidc/clients/SyncAuthClientImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/SyncAuthClientImpl.java
@@ -125,4 +125,24 @@ class SyncAuthClientImpl extends AuthAPI implements SyncAuthClient {
     public SyncSessionClient getSessionClient() {
         return this.sessionClient;
     }
+
+    @Override
+    public int signOut() {
+        return signOut(ALL);
+    }
+
+    @Override
+    public int signOut(int flags) {
+        try {
+            mSignOutStatus = SUCCESS;
+            mSignOutFlags = flags;
+            revokeTokens(getSessionClient());
+            removeTokens(getSessionClient());
+            return mSignOutStatus;
+        } catch (IOException e) {
+            return FAILED_ALL;
+        } finally {
+            resetCurrentState();
+        }
+    }
 }

--- a/library/src/main/java/com/okta/oidc/clients/web/SyncWebAuthClient.java
+++ b/library/src/main/java/com/okta/oidc/clients/web/SyncWebAuthClient.java
@@ -149,4 +149,45 @@ public interface SyncWebAuthClient extends BaseAuth<SyncSessionClient> {
      * @param data        the redirected data from chrome custom tab.
      */
     void handleActivityResult(int requestCode, int resultCode, Intent data);
+
+    /**
+     * Convenience method to completely sign out of application.
+     * Performs the following operations in order:
+     * 1. Revokes the access_token. If this fails step 3 will not be attempted.
+     * 2. Revokes the refresh_token. If this fails step 3 will not be attempted.
+     * 3. Removes all persistence data. Only if steps 1 & 2 succeeds.
+     * 4. Clears browser session only if this is a {@link com.okta.oidc.clients.web.WebAuthClient}
+     * instance. Will always be attempted regardless of the other operations.
+     *
+     * @param activity the activity
+     * @return the bitwise status.
+     * @see #SUCCESS
+     * @see #FAILED_REVOKE_ACCESS_TOKEN
+     * @see #FAILED_REVOKE_REFRESH_TOKEN
+     * @see #FAILED_CLEAR_DATA
+     * @see #FAILED_CLEAR_SESSION
+     */
+    int signOut(@NonNull Activity activity);
+
+    /**
+     * Convenience method to completely sign out of application.
+     * Performs the following depending on the flags parameter:
+     * {@link #REVOKE_ACCESS_TOKEN} Perform revoke access_token operation.
+     * {@link #REVOKE_REFRESH_TOKEN} Perform revoke the refresh_token operation.
+     * {@link #REMOVE_TOKENS} Removes all persistent data. Attempted only if revoke tokens succeeds
+     * or no flag is set to revoke tokens.
+     * {@link #SIGN_OUT_SESSION} Clears browser session if this is a
+     * {@link com.okta.oidc.clients.web.WebAuthClient} instance.
+     * {@link #ALL} All of the above flags. Same as calling {@link #signOut}
+     *
+     * @param activity the activity
+     * @param flags    the flag for the operations to perform.
+     * @return the bitwise status.
+     * @see #SUCCESS
+     * @see #FAILED_REVOKE_ACCESS_TOKEN
+     * @see #FAILED_REVOKE_REFRESH_TOKEN
+     * @see #FAILED_CLEAR_DATA
+     * @see #FAILED_CLEAR_SESSION
+     */
+    int signOut(@NonNull Activity activity, int flags);
 }

--- a/library/src/main/java/com/okta/oidc/clients/web/WebAuthClient.java
+++ b/library/src/main/java/com/okta/oidc/clients/web/WebAuthClient.java
@@ -22,6 +22,7 @@ import androidx.annotation.NonNull;
 
 import com.okta.oidc.AuthenticationPayload;
 import com.okta.oidc.AuthorizationStatus;
+import com.okta.oidc.RequestCallback;
 import com.okta.oidc.ResultCallback;
 import com.okta.oidc.clients.BaseAuth;
 import com.okta.oidc.clients.sessions.SessionClient;
@@ -156,4 +157,49 @@ public interface WebAuthClient extends BaseAuth<SessionClient> {
      * @param data        the redirected data from chrome custom tab.
      */
     void handleActivityResult(int requestCode, int resultCode, Intent data);
+
+    /**
+     * Convenience method to completely sign out of application.
+     * Performs the following operations in order:
+     * 1. Revokes the access_token. If this fails step 3 will not be attempted.
+     * 2. Revokes the refresh_token. If this fails step 3 will not be attempted.
+     * 3. Removes all persistence data. Only if steps 1 & 2 succeeds.
+     * 4. Clears browser session only if this is a {@link com.okta.oidc.clients.web.WebAuthClient}
+     * instance. Will always be attempted regardless of the other operations.
+     *
+     * @param activity        the activity
+     * @param requestCallback the callback containing the bitwise status. AuthorizationException
+     *                        may be null.
+     * @see #SUCCESS
+     * @see #FAILED_REVOKE_ACCESS_TOKEN
+     * @see #FAILED_REVOKE_REFRESH_TOKEN
+     * @see #FAILED_CLEAR_DATA
+     * @see #FAILED_CLEAR_SESSION
+     */
+    void signOut(@NonNull Activity activity,
+                 RequestCallback<Integer, AuthorizationException> requestCallback);
+
+    /**
+     * Convenience method to completely sign out of application.
+     * Performs the following depending on the flags parameter:
+     * {@link #REVOKE_ACCESS_TOKEN} Perform revoke access_token operation.
+     * {@link #REVOKE_REFRESH_TOKEN} Perform revoke the refresh_token operation.
+     * {@link #REMOVE_TOKENS} Removes all persistent data. Attempted only if revoke tokens succeeds
+     * or no flag is set to revoke tokens.
+     * {@link #SIGN_OUT_SESSION} Clears browser session if this is a
+     * {@link com.okta.oidc.clients.web.WebAuthClient} instance.
+     * {@link #ALL} All of the above flags. Same as calling {@link #signOut}
+     *
+     * @param activity        the activity
+     * @param flags           the flag for the operations to perform.
+     * @param requestCallback the callback containing the bitwise status. AuthorizationException
+     *                        may be null.
+     * @see #SUCCESS
+     * @see #FAILED_REVOKE_ACCESS_TOKEN
+     * @see #FAILED_REVOKE_REFRESH_TOKEN
+     * @see #FAILED_CLEAR_DATA
+     * @see #FAILED_CLEAR_SESSION
+     */
+    void signOut(@NonNull Activity activity, int flags,
+                 RequestCallback<Integer, AuthorizationException> requestCallback);
 }

--- a/library/src/main/java/com/okta/oidc/clients/web/WebAuthClientImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/web/WebAuthClientImpl.java
@@ -26,6 +26,7 @@ import androidx.annotation.NonNull;
 import com.okta.oidc.AuthenticationPayload;
 import com.okta.oidc.AuthorizationStatus;
 import com.okta.oidc.OIDCConfig;
+import com.okta.oidc.RequestCallback;
 import com.okta.oidc.RequestDispatcher;
 import com.okta.oidc.ResultCallback;
 import com.okta.oidc.clients.sessions.SessionClient;
@@ -222,6 +223,25 @@ class WebAuthClientImpl implements WebAuthClient {
     @Override
     public SessionClient getSessionClient() {
         return mSessionImpl;
+    }
+
+    @Override
+    public void signOut(@NonNull final Activity activity,
+                        RequestCallback<Integer, AuthorizationException> callback) {
+        signOut(activity, ALL, callback);
+    }
+
+    @Override
+    public void signOut(@NonNull final Activity activity, int flags,
+                        RequestCallback<Integer, AuthorizationException> callback) {
+        mFutureTask = mDispatcher.submit(() -> {
+            final int status = mSyncAuthClient.signOut(activity, flags);
+            mDispatcher.submitResults(() -> {
+                if (callback != null) {
+                    callback.onSuccess(status);
+                }
+            });
+        });
     }
 
     private void cancelFuture() {

--- a/library/src/test/java/com/okta/oidc/clients/web/SyncWebAuthClientTest.java
+++ b/library/src/test/java/com/okta/oidc/clients/web/SyncWebAuthClientTest.java
@@ -15,6 +15,7 @@
 
 package com.okta.oidc.clients.web;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -32,6 +33,7 @@ import com.okta.oidc.OktaState;
 import com.okta.oidc.net.OktaHttpClient;
 import com.okta.oidc.net.request.ConfigurationRequest;
 import com.okta.oidc.net.request.ProviderConfiguration;
+import com.okta.oidc.net.request.RevokeTokenRequest;
 import com.okta.oidc.net.request.TokenRequest;
 import com.okta.oidc.net.request.web.AuthorizeRequest;
 import com.okta.oidc.net.response.TokenResponse;
@@ -45,9 +47,12 @@ import com.okta.oidc.util.CodeVerifierUtil;
 import com.okta.oidc.util.EncryptionManagerStub;
 import com.okta.oidc.util.HttpClientFactory;
 import com.okta.oidc.util.MockEndPoint;
+import com.okta.oidc.util.HttpClientFactory;
+import com.okta.oidc.util.MockRequestCallback;
 import com.okta.oidc.util.TestValues;
 
 import org.json.JSONException;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -78,6 +83,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
 @Config(sdk = 27)
@@ -248,7 +254,7 @@ public class SyncWebAuthClientTest {
         mSyncWebAuth.getSessionClient().clear();
         Result result = mSyncWebAuth.signOutOfOkta(Robolectric.setupActivity(FragmentActivity.class));
         assertNotNull(result.getError());
-        assertTrue(result.getError().getCause() instanceof NullPointerException);
+        Assert.assertTrue(result.getError().getCause() instanceof NullPointerException);
     }
 
     @Test
@@ -256,7 +262,7 @@ public class SyncWebAuthClientTest {
         AuthorizeResponse response = AuthorizeResponse.
                 fromUri(Uri.parse(String.format(TestValues.EMAIL_AUTHENTICATED, mEndPoint.getUrl())));
 
-        assertTrue(mSyncWebAuth.isVerificationFlow(response));
+        Assert.assertTrue(mSyncWebAuth.isVerificationFlow(response));
         Result result = mSyncWebAuth.processEmailVerification(response);
         assertEquals(AuthorizationStatus.EMAIL_VERIFICATION_AUTHENTICATED, result.getStatus());
         assertNull(result.getLoginHint());
@@ -267,7 +273,7 @@ public class SyncWebAuthClientTest {
         AuthorizeResponse response = AuthorizeResponse.
                 fromUri(Uri.parse(String.format(TestValues.EMAIL_UNAUTHENTICATED, mEndPoint.getUrl())));
 
-        assertTrue(mSyncWebAuth.isVerificationFlow(response));
+        Assert.assertTrue(mSyncWebAuth.isVerificationFlow(response));
         Result result = mSyncWebAuth.processEmailVerification(response);
         assertEquals(AuthorizationStatus.EMAIL_VERIFICATION_UNAUTHENTICATED, result.getStatus());
         assertEquals(TestValues.LOGIN_HINT, result.getLoginHint());


### PR DESCRIPTION
#### Description:
Helper API that does sign out by revoking tokens, signing out of browser session and
remove persistent data.

#### Testing details:
- [x]  Verified basic functionality of change
- [x]  Added tests 

##### RESOLVES: 
[OKTA-239591](https://oktainc.atlassian.net/browse/OKTA-239591)

