### PR TITLE
Don't use OEAP spec workaround if using strongbox.

### DIFF
--- a/library/src/main/java/com/okta/oidc/storage/security/BaseEncryptionManager.java
+++ b/library/src/main/java/com/okta/oidc/storage/security/BaseEncryptionManager.java
@@ -59,6 +59,7 @@ abstract class BaseEncryptionManager implements EncryptionManager {
     protected String mBlockMode;
     protected String mEncryptionPadding;
     protected String mTransformationString;
+    protected boolean mIsStrongBoxBacked;
 
     private static final int RSA_KEY_SIZE = 2048;
     // RSA doesn't support encryption of lot amount of data.
@@ -227,8 +228,10 @@ abstract class BaseEncryptionManager implements EncryptionManager {
         PublicKey unrestricted = KeyFactory.getInstance(key.getAlgorithm())
                 .generatePublic(new X509EncodedKeySpec(key.getEncoded()));
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !mIsStrongBoxBacked) {
             // from https://code.google.com/p/android/issues/detail?id=197719
+            // This workaround of using the OAEP spec is not compatible when strong box is used.
+            // Currently the only device is the PIXEL 3.
             OAEPParameterSpec spec = new OAEPParameterSpec("SHA-256", "MGF1",
                     MGF1ParameterSpec.SHA1, PSource.PSpecified.DEFAULT);
 

--- a/library/src/main/java/com/okta/oidc/storage/security/EncryptionManagerAPI23.java
+++ b/library/src/main/java/com/okta/oidc/storage/security/EncryptionManagerAPI23.java
@@ -88,6 +88,7 @@ class EncryptionManagerAPI23 extends BaseEncryptionManager {
                 // In Android P was introduced new way to persist keystore - StrongBox
                 // If device doesn't support StrongBox, it will use TEE implementation if present.
                 builder.setIsStrongBoxBacked(isStrongBoxBacked);
+                mIsStrongBoxBacked = isStrongBoxBacked;
             }
 
             if (seed != null && seed.length > 0) {


### PR DESCRIPTION
#### Description:
Don't use the OEAP spec to initialize the cipher if
device uses strong box.

#### Testing details:
- [x]  Verified basic functionality of change

##### RESOLVES: 
[OKTA-246722](https://oktainc.atlassian.net/browse/OKTA-246722)

