### PR TITLE
fix espresso tests. Add copyright notices

### DIFF
--- a/app/src/androidTest/java/com/okta/oidc/example/EncryptionTest.java
+++ b/app/src/androidTest/java/com/okta/oidc/example/EncryptionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License,
+ * Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
 package com.okta.oidc.example;
 
 import android.content.Context;
@@ -48,7 +63,7 @@ public class EncryptionTest {
         boolean hardwareBacked = mEncryptionManager.isHardwareBackedKeyStore();
         if (SampleActivity.isEmulator()) {
             // Starting from API 26, isHardwareBackedKeyStore on emulator return true
-            if(Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
                 assertFalse(hardwareBacked);
             } else {
                 assertTrue(hardwareBacked);

--- a/app/src/androidTest/java/com/okta/oidc/example/MfaTest.java
+++ b/app/src/androidTest/java/com/okta/oidc/example/MfaTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License,
+ * Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
 package com.okta.oidc.example;
 
 import android.os.RemoteException;

--- a/app/src/main/java/com/okta/oidc/example/PlainActivity.java
+++ b/app/src/main/java/com/okta/oidc/example/PlainActivity.java
@@ -142,7 +142,7 @@ public class PlainActivity extends Activity {
 
         mSignInBrowser.setOnClickListener(v -> {
             showNetworkProgress(true);
-            mWebAuth.signIn(this, null);
+            mWebAuth.signIn(this, mPayload);
         });
 
         mSocialLogin.setOnClickListener(v -> {


### PR DESCRIPTION
Espresso test was failing due to payload not being provided. This cause the test for loginHint to fail.

