### PR TITLE
Deprecate authorizedRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,27 +405,32 @@ In `onSuccess` the userinfo returned is a `UserInfo` with the [response properti
 
 ### Performing authorized requests
 
-In addition to the built in endpoints, you can use the client interface to perform your own authorized requests, whatever they might be. You can call `authorizedRequest` requests and have the access token automatically added to the `Authorization` header with the standard OAuth 2.0 prefix of `Bearer`.
+Authorized request to your own server endpoints will need to add the `Authorization` header with the `access token`, prefixed by the standard OAuth 2.0 of `Bearer`.
+If you are using Android's standard `HttpURLConnection` you can set the headers like the following:
 
 ```java
-final Uri uri;
-Map<String, String> properties = new HashMap<>();
-properties.put("queryparam", "queryparam");
-Map<String, String> postParameters = new HashMap<>();
-postParameters.put("postparam", "postparam");
+try {
+    Tokens token = client.getSessionClient.getTokens();
+    URL url = new URL("yourCustomUrl");
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setRequestProperty("Authorization", "Bearer " + token.getAccessToken());
+} catch (AuthorizationException e) {
+    //handle error
+}
+```
 
-client.getSessionClient().authorizedRequest(uri, properties,
-                postParameters, ConnectionParameters.RequestMethod.POST, new RequestCallback<JSONObject, AuthorizationException>() {
-    @Override
-    public void onSuccess(@NonNull JSONObject result) {
-        //handle JSONObject result.
-    }
+If you are using `OkHttp` you can set the headers in the `Request` like the following:
 
-    @Override
-    public void onError(String error, AuthorizationException exception) {
-        //handle failed request
-    }
-});
+```java
+try {
+    Tokens token = client.getSessionClient.getTokens();
+    Request request = new Request.Builder()
+        .url("yourCustomUrl")
+        .addHeader("Authorization", "Bearer " + token.getAccessToken())
+        .build();
+} catch (AuthorizationException e) {
+    //handle error
+}
 ```
 
 ### Refresh a Token

--- a/library/src/main/java/com/okta/oidc/clients/sessions/SessionClient.java
+++ b/library/src/main/java/com/okta/oidc/clients/sessions/SessionClient.java
@@ -93,6 +93,7 @@ public interface SessionClient extends BaseSessionClient {
      * @param method         the http method {@link ConnectionParameters.RequestMethod}
      * @param cb             the RequestCallback to be executed when request is finished.
      */
+    @Deprecated
     void authorizedRequest(@NonNull Uri uri, @Nullable Map<String, String> properties,
                            @Nullable Map<String, String> postParameters,
                            @NonNull ConnectionParameters.RequestMethod method,


### PR DESCRIPTION
#### Description:
authorizedRequest should not be handled by the SDK.
It is creating more problems than it solves.
Developers should add the Authorization header themselves
in http network calls.


