### PR TITLE
fix issue where even though chrome is installed it cannot be found

### DIFF
--- a/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
+++ b/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
@@ -43,6 +43,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.M;
 import static com.okta.oidc.net.ConnectionParameters.USER_AGENT_HEADER;
 import static com.okta.oidc.net.ConnectionParameters.X_OKTA_USER_AGENT;
 
@@ -170,7 +172,8 @@ public class OktaAuthenticationActivity extends Activity {
     protected String getBrowser() {
         PackageManager pm = getPackageManager();
         Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.example.com"));
-        List<ResolveInfo> resolveInfoList = pm.queryIntentActivities(browserIntent, 0);
+        int flag = SDK_INT >= M ? PackageManager.MATCH_ALL : 0;
+        List<ResolveInfo> resolveInfoList = pm.queryIntentActivities(browserIntent, flag);
         List<String> customTabsBrowsers = new ArrayList<>();
         for (ResolveInfo info : resolveInfoList) {
             Intent serviceIntent = new Intent();


### PR DESCRIPTION
#### Description:
Since package manager flag was set to `0` android would only return the default browser. Even though chrome is installed it is not in the resolved list of browsers. Setting the flag to `MATCH_ALL` would resolve to all available browsers. 

https://developer.android.com/reference/android/content/pm/PackageManager#MATCH_ALL
https://medium.com/google-developer-experts/intent-resolving-in-android-m-c17d39d27048

#### Testing details:
Hard to automate testing. Could be verified by using a samsung device where the default browser app is Samsung Internet.

#### Primary Reviewer(s):
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):