### PR TITLE
Default to first compatible browser if none found.

### DIFF
--- a/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
+++ b/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
@@ -185,6 +185,10 @@ public class OktaAuthenticationActivity extends Activity {
                 return browser;
             }
         }
+        //Use first compatible browser on list.
+        if (!customTabsBrowsers.isEmpty()) {
+            return customTabsBrowsers.get(0);
+        }
         return null;
     }
 


### PR DESCRIPTION
#### Description:
Fix a bug where if the device doesn't contain the preferred
browsers it returns null.
This fix will return the first compatible browser if none is found
from the preferred list.

#### Testing details:
- [x]  Verified basic functionality of change