### PR TITLE
Custom configuration option. Browser flag with match all option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ webClient.registerCallback(new ResultCallback<AuthorizationStatus, Authorization
 
 The `client` can now be used to authenticate users and authorize access.
 
-**Note**: `.well-known/openid-configuration` or `.well-known/oauth-authorization-server` will be appended to your `discoveryUri` if it is missing.
+**Note**: `.well-known/openid-configuration` will be appended to your `discoveryUri` if it is missing.
 
-- `discoveryUri` is: `https://{yourOktaDomain}/oauth2/${authServerId}` then `.well-known/oauth-authorization-server` is added.
+- `discoveryUri` is: `https://{yourOktaDomain}/oauth2/${authServerId}` then `.well-known/openid-configuration` is added.
 - `discoveryUri` is: `https://{yourOktaDomain}` then `.well-known/openid-configuration` is added.
-- `discoveryUri` is: `https://{yourOktaDomain}/oauth2/default` then `.well-known/oauth-authorization-server` is added.
+- `discoveryUri` is: `https://{yourOktaDomain}/oauth2/default` then `.well-known/openid-configuration` is added.
 - `discoveryUri` is: `https://{yourOktaDomain}/oauth2/${authServerId}/.well-known/openid-configuration` nothing is added.
 - `discoveryUri` is: `https://{yourOktaDomain}/oauth2/${authServerId}/.well-known/oauth-authorization-server` nothing is added.
 
@@ -169,6 +169,26 @@ Use this JSON file to create a `configuration`:
 ```java
 OIDCConfig config = new OIDCConfig.Builder()
     .withJsonFile(this, R.raw.okta_oidc_config)
+    .create();
+```
+## Configuration without discoveryUri
+
+It is recommended to use `discoveryUri` to retrieve your authorization providers configuration.
+But if your provider does not have a `discoveryUri` you can provide the URIs to the endpoints
+yourself like the following:
+
+```java
+CustomConfiguration config = new CustomConfiguration.Builder()
+    .tokenEndpoint("{yourTokenEndpoint}")
+    .authorizationEndpoint("{yourAuthorizeEndpoint}")
+    .create();
+        
+mOidcConfig = new OIDCConfig.Builder()
+    .clientId(BuildConfig.CLIENT_ID)
+    .redirectUri(BuildConfig.REDIRECT_URI)
+    .endSessionRedirectUri(BuildConfig.END_SESSION_URI)
+    .scopes(BuildConfig.SCOPES)
+    .customConfiguration(config)
     .create();
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,12 +51,12 @@ android {
 dependencies {
     implementation project(':library')
     implementation 'androidx.fragment:fragment:' + rootProject.androidxLibVersion
-    implementation 'androidx.annotation:annotation:' + rootProject.androidxLibVersion
-    implementation 'androidx.appcompat:appcompat:' + rootProject.androidxLibVersion
+    implementation 'androidx.annotation:annotation:' + rootProject.appcompatVersion
+    implementation 'androidx.appcompat:appcompat:' + rootProject.appcompatVersion
     implementation 'androidx.security:security-crypto:' + rootProject.securityVersion
 
     implementation "com.google.android.material:material:1.0.0"
-    implementation 'androidx.biometric:biometric:1.0.0'
+    implementation 'androidx.biometric:biometric:1.0.1'
     implementation 'com.okta.authn.sdk:okta-authn-sdk-api:1.0.0'
     implementation('com.okta.authn.sdk:okta-authn-sdk-impl:1.0.0') {
         exclude group: 'com.okta.sdk', module: 'okta-sdk-httpclient'
@@ -69,7 +69,7 @@ dependencies {
     // Assertions
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.ext:truth:1.2.0'
-    androidTestImplementation 'com.google.truth:truth:1.0'
+    androidTestImplementation 'com.google.truth:truth:1.0.1'
 
     // AndroidJUnitRunner and JUnit Rules
     androidTestImplementation 'androidx.test:runner:1.2.0'
@@ -86,7 +86,7 @@ dependencies {
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:' + rootProject.uiautomatorVersion
     androidTestImplementation 'org.hamcrest:hamcrest-integration:1.3'
 
-    androidTestImplementation 'com.github.tomakehurst:wiremock-standalone:2.24.1'
+    androidTestImplementation 'com.github.tomakehurst:wiremock-standalone:2.25.1'
 
     androidTestImplementation "io.jsonwebtoken:jjwt-api:${rootProject.jsonWebTokenVersion}"
     androidTestImplementation "io.jsonwebtoken:jjwt-impl:${rootProject.jsonWebTokenVersion}"

--- a/app/src/androidTest/java/com/okta/oidc/example/EncryptionTest.java
+++ b/app/src/androidTest/java/com/okta/oidc/example/EncryptionTest.java
@@ -62,8 +62,8 @@ public class EncryptionTest {
     public void checkHardwareKeystore() {
         boolean hardwareBacked = mEncryptionManager.isHardwareBackedKeyStore();
         if (SampleActivity.isEmulator()) {
-            // Starting from API 26, isHardwareBackedKeyStore on emulator return true
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            //API 26, isHardwareBackedKeyStore on emulator return true
+            if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
                 assertFalse(hardwareBacked);
             } else {
                 assertTrue(hardwareBacked);

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'org.owasp:dependency-check-gradle:5.2.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -42,23 +42,23 @@ ext {
     minSdkVersion = 19
     compileSdkVersion = 29
     buildToolsVersion = "29.0.2"
-    browserVersion = '1.0.0'
-    appcompatVersion = '1.0.0'
+    browserVersion = '1.2.0'
+    appcompatVersion = '1.1.0'
     // SDK dependency versions
     bintrayVersion = "1.8.4"
     gradlePluginVersion = "1.5"
-    gsonVersion = "2.8.5"
+    gsonVersion = "2.8.6"
 
     // Test dependency versions
-    junitVersion = "4.12"
+    junitVersion = '4.13'
     mockitoVersion = "2.13.0"
-    robolectricVersion = '4.3'
-    okhttpVersion = '4.2.0'
+    robolectricVersion = '4.3.1'
+    okhttpVersion = '4.3.1'
     jsonWebTokenVersion = '0.10.7'
-    assertjCoreVersion = '3.13.2'
+    assertjCoreVersion = '3.14.0'
     assertjVersion = "1.2.0"
 
-    androidxLibVersion = "1.1.0"
+    androidxLibVersion = "1.2.0"
     espressoVersion = "3.2.0"
     uiautomatorVersion = "2.2.0"
     securityVersion = "1.0.0-alpha02"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation "com.google.code.gson:gson:${rootProject.gsonVersion}"
     implementation "androidx.browser:browser:${rootProject.browserVersion}"
     implementation "androidx.fragment:fragment:${rootProject.androidxLibVersion}"
-    implementation "androidx.core:core:${rootProject.androidxLibVersion}"
+    implementation "androidx.core:core:${rootProject.appcompatVersion}"
     testImplementation "com.squareup.okhttp3:okhttp-tls:${rootProject.okhttpVersion}"
     testImplementation "io.jsonwebtoken:jjwt-jackson:${rootProject.jsonWebTokenVersion}"
     testImplementation("io.jsonwebtoken:jjwt-orgjson:${rootProject.jsonWebTokenVersion}") {

--- a/library/src/main/java/com/okta/oidc/CustomConfiguration.java
+++ b/library/src/main/java/com/okta/oidc/CustomConfiguration.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2020, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License,
+ * Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.okta.oidc;
+
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Used for authorization servers that does not provide a discovery endpoint.
+ * It is recommended to use {@link com.okta.oidc.OIDCConfig.Builder#discoveryUri(String)}
+ * to fetch the Open ID provider configuration instead.
+ *
+ * @see "OpenID provider issuer discovery <https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery"
+ */
+@SuppressWarnings("unused")
+public class CustomConfiguration {
+    private String mAuthorizationEndpoint;
+    private String mTokenEndpoint;
+    private String mUserInfoEndpoint;
+    private String mJwksUri;
+    private String mRegistrationEndpoint;
+    private String mIntrospectionEndpoint;
+    private String mRevocationEndpoint;
+    private String mEndSessionEndpoint;
+
+    /**
+     * Gets authorization endpoint.
+     *
+     * @return the authorization endpoint
+     */
+    public String getAuthorizationEndpoint() {
+        return mAuthorizationEndpoint;
+    }
+
+    /**
+     * Gets token endpoint.
+     *
+     * @return the token endpoint
+     */
+    public String getTokenEndpoint() {
+        return mTokenEndpoint;
+    }
+
+    /**
+     * Gets user info endpoint.
+     *
+     * @return the user info endpoint
+     */
+    public String getUserInfoEndpoint() {
+        return mUserInfoEndpoint;
+    }
+
+    /**
+     * Gets jwks uri.
+     *
+     * @return the jwks uri
+     */
+    public String getJwksUri() {
+        return mJwksUri;
+    }
+
+    /**
+     * Gets registration endpoint.
+     *
+     * @return the registration endpoint
+     */
+    public String getRegistrationEndpoint() {
+        return mRegistrationEndpoint;
+    }
+
+    /**
+     * Gets introspection endpoint.
+     *
+     * @return the introspection endpoint
+     */
+    public String getIntrospectionEndpoint() {
+        return mIntrospectionEndpoint;
+    }
+
+    /**
+     * Gets revocation endpoint.
+     *
+     * @return the revocation endpoint
+     */
+    public String getRevocationEndpoint() {
+        return mRevocationEndpoint;
+    }
+
+    /**
+     * Gets end session endpoint.
+     *
+     * @return the end session endpoint
+     */
+    public String getEndSessionEndpoint() {
+        return mEndSessionEndpoint;
+    }
+
+    private CustomConfiguration() {
+    }
+
+    /**
+     * The CustomConfiguration Builder for setting endpoints for Okta OpenID provider.
+     *
+     * @see "OpenID Connect & OAuth 2.0 API <https://developer.okta.com/docs/reference/api/oidc/#endpoints"
+     */
+    public static class Builder {
+        private CustomConfiguration mConfiguration;
+
+        /**
+         * Instantiates a new Builder for CustomConfiguration.
+         */
+        public Builder() {
+            mConfiguration = new CustomConfiguration();
+        }
+
+        /**
+         * Required authorization endpoint.
+         *
+         * @param authorizationEndpoint the authorization endpoint
+         * @return the builder
+         */
+        public Builder authorizationEndpoint(@NonNull String authorizationEndpoint) {
+            mConfiguration.mAuthorizationEndpoint = authorizationEndpoint;
+            return this;
+        }
+
+        /**
+         * Required token endpoint.
+         *
+         * @param tokenEndpoint the token endpoint
+         * @return the builder
+         */
+        public Builder tokenEndpoint(@NonNull String tokenEndpoint) {
+            mConfiguration.mTokenEndpoint = tokenEndpoint;
+            return this;
+        }
+
+        /**
+         * Optional user info endpoint.
+         *
+         * @param userInfoEndpoint the user info endpoint
+         * @return the builder
+         */
+        public Builder userInfoEndpoint(@NonNull String userInfoEndpoint) {
+            mConfiguration.mUserInfoEndpoint = userInfoEndpoint;
+            return this;
+        }
+
+        /**
+         * Optional Jwks uri.
+         *
+         * @param jwksUri the jwks uri
+         * @return the builder
+         */
+        public Builder jwksUri(@NonNull String jwksUri) {
+            mConfiguration.mJwksUri = jwksUri;
+            return this;
+        }
+
+        /**
+         * Optional registration endpoint.
+         *
+         * @param registrationEndpoint the registration endpoint
+         * @return the builder
+         */
+        public Builder registrationEndpoint(@NonNull String registrationEndpoint) {
+            mConfiguration.mRegistrationEndpoint = registrationEndpoint;
+            return this;
+        }
+
+        /**
+         * Optional introspection endpoint.
+         *
+         * @param introspectionEndpoint the introspection endpoint
+         * @return the builder
+         */
+        public Builder introspectionEndpoint(@NonNull String introspectionEndpoint) {
+            mConfiguration.mIntrospectionEndpoint = introspectionEndpoint;
+            return this;
+        }
+
+        /**
+         * Optional revocation endpoint.
+         *
+         * @param revocationEndpoint the revocation endpoint
+         * @return the builder
+         */
+        public Builder revocationEndpoint(@NonNull String revocationEndpoint) {
+            mConfiguration.mRevocationEndpoint = revocationEndpoint;
+            return this;
+        }
+
+        /**
+         * Optional end session endpoint.
+         *
+         * @param endSessionEndpoint the end session endpoint
+         * @return the builder
+         */
+        public Builder endSessionEndpoint(@NonNull String endSessionEndpoint) {
+            mConfiguration.mEndSessionEndpoint = endSessionEndpoint;
+            return this;
+        }
+
+        /**
+         * Create the custom configuration.
+         *
+         * @return Custom configuration
+         * @throws IllegalStateException - If missing required endpoints.
+         */
+        public CustomConfiguration create() throws IllegalStateException {
+            validate();
+            return mConfiguration;
+        }
+
+        private void validate() {
+            if (TextUtils.isEmpty(mConfiguration.getAuthorizationEndpoint())) {
+                throw new IllegalStateException("No authorization endpoint specified");
+            }
+            if (TextUtils.isEmpty(mConfiguration.getTokenEndpoint())) {
+                throw new IllegalStateException("No token endpoint specified");
+            }
+        }
+    }
+}

--- a/library/src/main/java/com/okta/oidc/CustomTabOptions.java
+++ b/library/src/main/java/com/okta/oidc/CustomTabOptions.java
@@ -23,7 +23,7 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.RestrictTo;
 
 /**
- * Custom tab options for color and animation transitions.
+ * Custom tab options for browser. Color, animation, transitions, etc
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class CustomTabOptions implements Parcelable {
@@ -40,6 +40,8 @@ public class CustomTabOptions implements Parcelable {
     private int mEndEnterResId;
     @AnimRes
     private int mEndExitResId;
+
+    private int mBrowserMatchAllFlag;
 
     public int getCustomTabColor() {
         return mCustomTabColor;
@@ -81,6 +83,14 @@ public class CustomTabOptions implements Parcelable {
         mEndExitResId = endExitResId;
     }
 
+    public int getBrowserMatchAllFlag() {
+        return mBrowserMatchAllFlag;
+    }
+
+    public void setBrowserMatchAllFlag(int browserMatchAll) {
+        mBrowserMatchAllFlag = browserMatchAll;
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -93,6 +103,7 @@ public class CustomTabOptions implements Parcelable {
         dest.writeInt(mStartExitResId);
         dest.writeInt(mEndEnterResId);
         dest.writeInt(mEndExitResId);
+        dest.writeInt(mBrowserMatchAllFlag);
     }
 
     public static final Parcelable.Creator<CustomTabOptions> CREATOR =
@@ -105,6 +116,7 @@ public class CustomTabOptions implements Parcelable {
                     options.setStartExitResId(source.readInt());
                     options.setEndEnterResId(source.readInt());
                     options.setEndExitResId(source.readInt());
+                    options.setBrowserMatchAllFlag(source.readInt());
                     return options;
                 }
 

--- a/library/src/main/java/com/okta/oidc/Okta.java
+++ b/library/src/main/java/com/okta/oidc/Okta.java
@@ -15,6 +15,9 @@
 
 package com.okta.oidc;
 
+import android.content.pm.PackageManager;
+import android.os.Build;
+
 import androidx.annotation.AnimRes;
 import androidx.annotation.ColorInt;
 
@@ -105,6 +108,21 @@ public class Okta {
             return this;
         }
 
+        /**
+         * Sets the supported browsers query to use the MATCH_ALL intent flag.
+         *
+         * @param matchAll set true to use {@link android.content.pm.PackageManager#MATCH_ALL}
+         * @return current builder
+         */
+        public WebAuthBuilder browserMatchAll(boolean matchAll) {
+            int flag = 0;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && matchAll) {
+                flag = PackageManager.MATCH_ALL;
+            }
+            customTabOptions.setBrowserMatchAllFlag(flag);
+            return this;
+        }
+
         @Override
         protected WebAuthBuilder toThis() {
             return this;
@@ -179,6 +197,21 @@ public class Okta {
          */
         public SyncWebAuthBuilder supportedBrowsers(String... browsers) {
             mSupportedBrowsers = browsers;
+            return this;
+        }
+
+        /**
+         * Sets the supported browsers query to use the MATCH_ALL intent flag.
+         *
+         * @param matchAll set true to use {@link android.content.pm.PackageManager#MATCH_ALL}
+         * @return current builder
+         */
+        public SyncWebAuthBuilder browserMatchAll(boolean matchAll) {
+            int flag = 0;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && matchAll) {
+                flag = PackageManager.MATCH_ALL;
+            }
+            customTabOptions.setBrowserMatchAllFlag(flag);
             return this;
         }
 

--- a/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
+++ b/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
@@ -99,6 +99,7 @@ public class OktaAuthenticationActivity extends Activity {
     @VisibleForTesting
     protected CustomTabOptions mCustomTabOptions;
     private boolean mResultSent = false;
+    private int mMatchFlag;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -113,6 +114,9 @@ public class OktaAuthenticationActivity extends Activity {
         if (bundle != null) {
             mAuthUri = bundle.getParcelable(EXTRA_AUTH_URI);
             mCustomTabOptions = bundle.getParcelable(EXTRA_TAB_OPTIONS);
+            if (mCustomTabOptions != null) {
+                mMatchFlag = mCustomTabOptions.getBrowserMatchAllFlag();
+            }
             mAuthStarted = bundle.getBoolean(EXTRA_AUTH_STARTED, false);
             if (bundle.getString(EXTRA_EXCEPTION, null) != null) {
                 //login encountered exception pass same intent back to activity to handle.
@@ -171,7 +175,7 @@ public class OktaAuthenticationActivity extends Activity {
     protected String getBrowser() {
         PackageManager pm = getPackageManager();
         Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.example.com"));
-        List<ResolveInfo> resolveInfoList = pm.queryIntentActivities(browserIntent, 0);
+        List<ResolveInfo> resolveInfoList = pm.queryIntentActivities(browserIntent, mMatchFlag);
         List<String> customTabsBrowsers = new ArrayList<>();
         for (ResolveInfo info : resolveInfoList) {
             Intent serviceIntent = new Intent();

--- a/library/src/main/java/com/okta/oidc/OktaIdToken.java
+++ b/library/src/main/java/com/okta/oidc/OktaIdToken.java
@@ -304,27 +304,28 @@ public class OktaIdToken {
                     new IllegalStateException("JWT Header 'alg' of [" + mHeader.alg + "] " +
                             "is not supported, only RSA256 signatures are supported"));
         }
+        if (providerConfig.issuer != null) {
+            if (!mClaims.iss.equals(providerConfig.issuer)) {
+                throw AuthorizationException.fromTemplate(ID_TOKEN_VALIDATION_ERROR,
+                        new IllegalStateException("Issuer mismatch"));
+            }
 
-        if (!mClaims.iss.equals(providerConfig.issuer)) {
-            throw AuthorizationException.fromTemplate(ID_TOKEN_VALIDATION_ERROR,
-                    new IllegalStateException("Issuer mismatch"));
-        }
+            Uri issuerUri = Uri.parse(mClaims.iss);
+            if (!issuerUri.getScheme().equals("https")) {
+                throw AuthorizationException.fromTemplate(ID_TOKEN_VALIDATION_ERROR,
+                        new IllegalStateException("Issuer must be an https URL"));
+            }
 
-        Uri issuerUri = Uri.parse(mClaims.iss);
-        if (!issuerUri.getScheme().equals("https")) {
-            throw AuthorizationException.fromTemplate(ID_TOKEN_VALIDATION_ERROR,
-                    new IllegalStateException("Issuer must be an https URL"));
-        }
+            if (TextUtils.isEmpty(issuerUri.getHost())) {
+                throw AuthorizationException.fromTemplate(ID_TOKEN_VALIDATION_ERROR,
+                        new IllegalStateException("Issuer host can not be empty"));
+            }
 
-        if (TextUtils.isEmpty(issuerUri.getHost())) {
-            throw AuthorizationException.fromTemplate(ID_TOKEN_VALIDATION_ERROR,
-                    new IllegalStateException("Issuer host can not be empty"));
-        }
-
-        if (issuerUri.getFragment() != null || issuerUri.getQueryParameterNames().size() > 0) {
-            throw AuthorizationException.fromTemplate(ID_TOKEN_VALIDATION_ERROR,
-                    new IllegalStateException(
-                            "Issuer URL contains query parameters or fragment components"));
+            if (issuerUri.getFragment() != null || issuerUri.getQueryParameterNames().size() > 0) {
+                throw AuthorizationException.fromTemplate(ID_TOKEN_VALIDATION_ERROR,
+                        new IllegalStateException(
+                                "Issuer URL contains query parameters or fragment components"));
+            }
         }
 
         String clientId = config.getClientId();

--- a/library/src/main/java/com/okta/oidc/clients/AuthAPI.java
+++ b/library/src/main/java/com/okta/oidc/clients/AuthAPI.java
@@ -16,6 +16,7 @@
 package com.okta.oidc.clients;
 
 import android.content.Context;
+import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -91,12 +92,17 @@ public class AuthAPI {
     protected ProviderConfiguration obtainNewConfiguration() throws AuthorizationException {
         try {
             ProviderConfiguration config = mOktaState.getProviderConfiguration();
-            if (config == null ||
-                    !mOidcConfig.getDiscoveryUri().toString().contains(config.issuer)) {
-                mOktaState.setCurrentState(State.OBTAIN_CONFIGURATION);
-                ConfigurationRequest request = configurationRequest();
-                mCurrentRequest.set(new WeakReference<>(request));
-                config = request.executeRequest(mHttpClient);
+            Uri discoveryUri = mOidcConfig.getDiscoveryUri();
+            if (discoveryUri != null) {
+                if (config == null || !discoveryUri.toString().contains(config.issuer)) {
+                    mOktaState.setCurrentState(State.OBTAIN_CONFIGURATION);
+                    ConfigurationRequest request = configurationRequest();
+                    mCurrentRequest.set(new WeakReference<>(request));
+                    config = request.executeRequest(mHttpClient);
+                    mOktaState.save(config);
+                }
+            } else {
+                config = new ProviderConfiguration(mOidcConfig.getCustomConfiguration());
                 mOktaState.save(config);
             }
             return config;

--- a/library/src/main/java/com/okta/oidc/clients/sessions/SessionClientImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/sessions/SessionClientImpl.java
@@ -55,6 +55,9 @@ class SessionClientImpl implements SessionClient {
                 mDispatcher.submitResults(() -> cb.onSuccess(userInfo));
             } catch (AuthorizationException ae) {
                 mDispatcher.submitResults(() -> cb.onError(ae.error, ae));
+            } catch (Exception ex) {
+                mDispatcher.submitResults(() -> cb.onError(ex.getMessage(),
+                        new AuthorizationException(ex.getMessage(), ex)));
             }
         });
     }
@@ -70,6 +73,9 @@ class SessionClientImpl implements SessionClient {
                 mDispatcher.submitResults(() -> cb.onSuccess(introspectInfo));
             } catch (AuthorizationException ae) {
                 mDispatcher.submitResults(() -> cb.onError(ae.error, ae));
+            } catch (Exception ex) {
+                mDispatcher.submitResults(() -> cb.onError(ex.getMessage(),
+                        new AuthorizationException(ex.getMessage(), ex)));
             }
         });
     }
@@ -84,6 +90,9 @@ class SessionClientImpl implements SessionClient {
                 mDispatcher.submitResults(() -> cb.onSuccess(isRevoke));
             } catch (AuthorizationException ae) {
                 mDispatcher.submitResults(() -> cb.onError(ae.error, ae));
+            } catch (Exception ex) {
+                mDispatcher.submitResults(() -> cb.onError(ex.getMessage(),
+                        new AuthorizationException(ex.getMessage(), ex)));
             }
         });
     }
@@ -99,6 +108,9 @@ class SessionClientImpl implements SessionClient {
                 mDispatcher.submitResults(() -> cb.onSuccess(result));
             } catch (AuthorizationException ae) {
                 mDispatcher.submitResults(() -> cb.onError(ae.error, ae));
+            } catch (Exception ex) {
+                mDispatcher.submitResults(() -> cb.onError(ex.getMessage(),
+                        new AuthorizationException(ex.getMessage(), ex)));
             }
         });
     }
@@ -122,6 +134,9 @@ class SessionClientImpl implements SessionClient {
                 mDispatcher.submitResults(() -> cb.onSuccess(result));
             } catch (AuthorizationException ae) {
                 mDispatcher.submitResults(() -> cb.onError(ae.error, ae));
+            } catch (Exception ex) {
+                mDispatcher.submitResults(() -> cb.onError(ex.getMessage(),
+                        new AuthorizationException(ex.getMessage(), ex)));
             }
         });
     }

--- a/library/src/main/java/com/okta/oidc/net/request/ProviderConfiguration.java
+++ b/library/src/main/java/com/okta/oidc/net/request/ProviderConfiguration.java
@@ -23,6 +23,7 @@ import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 
 import com.google.gson.Gson;
+import com.okta.oidc.CustomConfiguration;
 import com.okta.oidc.storage.Persistable;
 
 /**
@@ -83,6 +84,17 @@ public class ProviderConfiguration implements Persistable {
     @VisibleForTesting
     public ProviderConfiguration() {
         //NO-OP
+    }
+
+    public ProviderConfiguration(CustomConfiguration config) {
+        authorization_endpoint = config.getAuthorizationEndpoint();
+        token_endpoint = config.getTokenEndpoint();
+        userinfo_endpoint = config.getUserInfoEndpoint();
+        jwks_uri = config.getJwksUri();
+        registration_endpoint = config.getRegistrationEndpoint();
+        introspection_endpoint = config.getIntrospectionEndpoint();
+        revocation_endpoint = config.getRevocationEndpoint();
+        end_session_endpoint = config.getEndSessionEndpoint();
     }
 
     void validate(boolean isOAuth2) throws IllegalArgumentException {

--- a/library/src/main/java/com/okta/oidc/net/request/TokenRequest.java
+++ b/library/src/main/java/com/okta/oidc/net/request/TokenRequest.java
@@ -165,6 +165,8 @@ public class TokenRequest extends BaseRequest<TokenResponse, AuthorizationExcept
         } catch (JSONException ex) {
             throw AuthorizationException.fromTemplate(
                     AuthorizationException.GeneralErrors.JSON_DESERIALIZATION_ERROR, ex);
+        } catch (AuthorizationException ae) {
+            throw ae;
         } catch (Exception e) {
             throw AuthorizationException.fromTemplate(AuthorizationException
                     .GeneralErrors.NETWORK_ERROR, e);

--- a/library/src/test/java/com/okta/oidc/CustomConfigurationTest.java
+++ b/library/src/test/java/com/okta/oidc/CustomConfigurationTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License,
+ * Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.okta.oidc;
+
+import com.okta.oidc.util.TestValues;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static com.okta.oidc.util.TestValues.AUTHORIZATION_ENDPOINT;
+import static com.okta.oidc.util.TestValues.CUSTOM_URL;
+import static com.okta.oidc.util.TestValues.END_SESSION_ENDPOINT;
+import static com.okta.oidc.util.TestValues.INTROSPECT_ENDPOINT;
+import static com.okta.oidc.util.TestValues.JWKS_ENDPOINT;
+import static com.okta.oidc.util.TestValues.REGISTRATION_ENDPOINT;
+import static com.okta.oidc.util.TestValues.REVOCATION_ENDPOINT;
+import static com.okta.oidc.util.TestValues.TOKEN_ENDPOINT;
+import static com.okta.oidc.util.TestValues.USERINFO_ENDPOINT;
+import static org.junit.Assert.*;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 27)
+public class CustomConfigurationTest {
+    private CustomConfiguration mConfig;
+
+    @Before
+    public void setUp() throws Exception {
+        mConfig = TestValues.getCustomConfiguration(CUSTOM_URL);
+    }
+
+    @Test
+    public void getAuthorizationEndpoint() {
+        String endpoint = mConfig.getAuthorizationEndpoint();
+        assertNotNull(endpoint);
+        assertEquals(CUSTOM_URL + AUTHORIZATION_ENDPOINT, endpoint);
+    }
+
+    @Test
+    public void getTokenEndpoint() {
+        String endpoint = mConfig.getTokenEndpoint();
+        assertNotNull(endpoint);
+        assertEquals(CUSTOM_URL + TOKEN_ENDPOINT, endpoint);
+    }
+
+    @Test
+    public void getUserInfoEndpoint() {
+        String endpoint = mConfig.getUserInfoEndpoint();
+        assertNotNull(endpoint);
+        assertEquals(CUSTOM_URL + USERINFO_ENDPOINT, endpoint);
+    }
+
+    @Test
+    public void getJwksUri() {
+        String endpoint = mConfig.getJwksUri();
+        assertNotNull(endpoint);
+        assertEquals(CUSTOM_URL + JWKS_ENDPOINT, endpoint);
+    }
+
+    @Test
+    public void getRegistrationEndpoint() {
+        String endpoint = mConfig.getRegistrationEndpoint();
+        assertNotNull(endpoint);
+        assertEquals(CUSTOM_URL + REGISTRATION_ENDPOINT, endpoint);
+    }
+
+    @Test
+    public void getIntrospectionEndpoint() {
+        String endpoint = mConfig.getIntrospectionEndpoint();
+        assertNotNull(endpoint);
+        assertEquals(CUSTOM_URL + INTROSPECT_ENDPOINT, endpoint);
+    }
+
+    @Test
+    public void getRevocationEndpoint() {
+        String endpoint = mConfig.getRevocationEndpoint();
+        assertNotNull(endpoint);
+        assertEquals(CUSTOM_URL + REVOCATION_ENDPOINT, endpoint);
+    }
+
+    @Test
+    public void getEndSessionEndpoint() {
+        String endpoint = mConfig.getEndSessionEndpoint();
+        assertNotNull(endpoint);
+        assertEquals(CUSTOM_URL + END_SESSION_ENDPOINT, endpoint);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidConfigurationNoTokenEndpoint() {
+        CustomConfiguration config = new CustomConfiguration.Builder()
+                .authorizationEndpoint(CUSTOM_URL + AUTHORIZATION_ENDPOINT)
+                .create();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidConfigurationNoAuthorizationEndpoint() {
+        CustomConfiguration config = new CustomConfiguration.Builder()
+                .tokenEndpoint(CUSTOM_URL + TOKEN_ENDPOINT)
+                .create();
+    }
+}

--- a/library/src/test/java/com/okta/oidc/OIDCConfigTest.java
+++ b/library/src/test/java/com/okta/oidc/OIDCConfigTest.java
@@ -47,11 +47,19 @@ import static org.mockito.Mockito.when;
 public class OIDCConfigTest {
     private OIDCConfig mConfig;
     private OIDCConfig mConfigOAuth2;
+    private OIDCConfig mWithCustomConfig;
 
     @Before
     public void setUp() throws Exception {
         mConfig = TestValues.getConfigWithUrl(CUSTOM_URL);
         mConfigOAuth2 = TestValues.getConfigWithUrl(CUSTOM_OAUTH2_URL);
+        mWithCustomConfig = new OIDCConfig.Builder()
+                .clientId(CLIENT_ID)
+                .redirectUri(REDIRECT_URI)
+                .endSessionRedirectUri(END_SESSION_URI)
+                .scopes(SCOPES)
+                .customConfiguration(TestValues.getCustomConfiguration(CUSTOM_URL))
+                .create();
     }
 
     @Test
@@ -106,8 +114,7 @@ public class OIDCConfigTest {
     public void getDiscoveryUriOAuth2() {
         Uri uri = mConfigOAuth2.getDiscoveryUri();
         assertNotNull(uri);
-        assertEquals(uri, Uri.parse(CUSTOM_OAUTH2_URL +
-                ProviderConfiguration.OAUTH2_CONFIGURATION_RESOURCE));
+        assertEquals(uri, Uri.parse(CUSTOM_OAUTH2_URL));
         assertTrue(mConfigOAuth2.isOAuth2Configuration());
     }
 
@@ -116,6 +123,24 @@ public class OIDCConfigTest {
         String[] scopes = mConfig.getScopes();
         assertNotNull(scopes);
         assertArrayEquals(SCOPES, scopes);
+    }
+
+    @Test
+    public void customConfiguration() {
+        CustomConfiguration configuration = mWithCustomConfig.getCustomConfiguration();
+        assertNotNull(configuration);
+        assertEquals(TestValues.getCustomConfiguration(CUSTOM_URL).getAuthorizationEndpoint(),
+                configuration.getAuthorizationEndpoint());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidConfiguration() {
+        new OIDCConfig.Builder()
+                .clientId(CLIENT_ID)
+                .redirectUri(REDIRECT_URI)
+                .endSessionRedirectUri(END_SESSION_URI)
+                .scopes(SCOPES)
+                .create();
     }
 
     @Test

--- a/library/src/test/java/com/okta/oidc/net/request/ConfigurationRequestTest.java
+++ b/library/src/test/java/com/okta/oidc/net/request/ConfigurationRequestTest.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static com.okta.oidc.util.TestValues.WELL_KNOWN_OAUTH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -77,7 +78,8 @@ public class ConfigurationRequestTest {
         mClientFactory = new HttpClientFactory();
         mClientFactory.setClientType(mClientType);
         mHttpClient = mClientFactory.build();
-        OIDCConfig configOAuth2 = TestValues.getConfigWithUrl(url + "/oauth2/default/");
+        OIDCConfig configOAuth2 =
+                TestValues.getConfigWithUrl(url + "/oauth2/default/" + WELL_KNOWN_OAUTH);
         mRequestOAuth2 = HttpRequestBuilder.newConfigurationRequest()
                 .config(configOAuth2)
                 .createRequest();

--- a/library/src/test/java/com/okta/oidc/net/request/ProviderConfigurationTest.java
+++ b/library/src/test/java/com/okta/oidc/net/request/ProviderConfigurationTest.java
@@ -25,8 +25,17 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import static com.okta.oidc.util.TestValues.AUTHORIZATION_ENDPOINT;
 import static com.okta.oidc.util.TestValues.CUSTOM_OAUTH2_URL;
 import static com.okta.oidc.util.TestValues.CUSTOM_URL;
+import static com.okta.oidc.util.TestValues.END_SESSION_ENDPOINT;
+import static com.okta.oidc.util.TestValues.INTROSPECT_ENDPOINT;
+import static com.okta.oidc.util.TestValues.JWKS_ENDPOINT;
+import static com.okta.oidc.util.TestValues.REGISTRATION_ENDPOINT;
+import static com.okta.oidc.util.TestValues.REVOCATION_ENDPOINT;
+import static com.okta.oidc.util.TestValues.TOKEN_ENDPOINT;
+import static com.okta.oidc.util.TestValues.USERINFO_ENDPOINT;
+import static com.okta.oidc.util.TestValues.getCustomConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -78,5 +87,19 @@ public class ProviderConfigurationTest {
         other.validate(false);
         assertNotNull(other);
         assertEquals(other.persist(), json);
+    }
+
+    @Test
+    public void useCustomConfiguration() {
+        ProviderConfiguration config =
+                new ProviderConfiguration(getCustomConfiguration(CUSTOM_URL));
+        assertEquals(CUSTOM_URL + END_SESSION_ENDPOINT, config.end_session_endpoint);
+        assertEquals(CUSTOM_URL + AUTHORIZATION_ENDPOINT, config.authorization_endpoint);
+        assertEquals(CUSTOM_URL + REVOCATION_ENDPOINT, config.revocation_endpoint);
+        assertEquals(CUSTOM_URL + JWKS_ENDPOINT, config.jwks_uri);
+        assertEquals(CUSTOM_URL + INTROSPECT_ENDPOINT, config.introspection_endpoint);
+        assertEquals(CUSTOM_URL + TOKEN_ENDPOINT, config.token_endpoint);
+        assertEquals(CUSTOM_URL + USERINFO_ENDPOINT, config.userinfo_endpoint);
+        assertEquals(CUSTOM_URL + REGISTRATION_ENDPOINT, config.registration_endpoint);
     }
 }

--- a/library/src/test/java/com/okta/oidc/util/TestValues.java
+++ b/library/src/test/java/com/okta/oidc/util/TestValues.java
@@ -18,6 +18,7 @@ import android.net.Uri;
 import android.text.TextUtils;
 
 import com.okta.oidc.AuthenticationPayload;
+import com.okta.oidc.CustomConfiguration;
 import com.okta.oidc.OIDCConfig;
 import com.okta.oidc.net.request.HttpRequestBuilder;
 import com.okta.oidc.net.request.IntrospectRequest;
@@ -47,7 +48,7 @@ import io.jsonwebtoken.security.Keys;
 
 public class TestValues {
     public static final String CUSTOM_URL = "https://com.okta.test/";
-    public static final String CUSTOM_OAUTH2_URL = "https://com.okta.test/oauth2/default/";
+    public static final String CUSTOM_OAUTH2_URL = "https://com.okta.test/oauth2/default/.well-known/oauth-authorization-server";
     public static final String WELL_KNOWN_OAUTH = ".well-known/oauth-authorization-server";
     public static final String WELL_KNOWN_OIDC = ".well-known/openid-configuration";
 
@@ -120,6 +121,19 @@ public class TestValues {
         configuration.end_session_endpoint = url + END_SESSION_ENDPOINT;
         configuration.userinfo_endpoint = url + USERINFO_ENDPOINT;
         return configuration;
+    }
+
+    public static CustomConfiguration getCustomConfiguration(String url) {
+        return new CustomConfiguration.Builder()
+                .authorizationEndpoint(url + AUTHORIZATION_ENDPOINT)
+                .endSessionEndpoint(url + END_SESSION_ENDPOINT)
+                .introspectionEndpoint(url + INTROSPECT_ENDPOINT)
+                .jwksUri(url + JWKS_ENDPOINT)
+                .registrationEndpoint(url + REGISTRATION_ENDPOINT)
+                .tokenEndpoint(url + TOKEN_ENDPOINT)
+                .userInfoEndpoint(url + USERINFO_ENDPOINT)
+                .revocationEndpoint(url + REVOCATION_ENDPOINT)
+                .create();
     }
 
     public static ProviderConfiguration getOAuth2ProviderConfiguration(String url) {


### PR DESCRIPTION
#### Description:
Update library dependencies.
Add custom configuration for servers that doesn't support discoveryUri.
Add option to use MATCH_ALL for browser intent matching.
Fix exception handling where exceptions that are not AuthorizationException
are failing silently.

#### Testing details:
- [x]  Verified basic functionality of change
- [x]  Added tests 
