### PR TITLE
:bug: Migrates to androidx.collection.ArrayMap

### DIFF
--- a/library/src/main/java/com/okta/oidc/util/AuthorizationException.java
+++ b/library/src/main/java/com/okta/oidc/util/AuthorizationException.java
@@ -20,7 +20,7 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import androidx.util.ArrayMap;
+import androidx.collection.ArrayMap;
 
 import com.okta.oidc.storage.OktaRepository.EncryptionException;
 

--- a/library/src/main/java/com/okta/oidc/util/AuthorizationException.java
+++ b/library/src/main/java/com/okta/oidc/util/AuthorizationException.java
@@ -16,11 +16,11 @@ package com.okta.oidc.util;
 
 import android.content.Intent;
 import android.net.Uri;
-import android.util.ArrayMap;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import androidx.util.ArrayMap;
 
 import com.okta.oidc.storage.OktaRepository.EncryptionException;
 


### PR DESCRIPTION
This moves to the androidx version of ArrayMap to fix an issue with accessing the code field of AuthorizationException class in classes under unit test in an Android project.

Resolves: #142

#### Description:

#### Testing details:
- [x]  Verified basic functionality of change
- [ ]  Added tests 

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes

##### RESOLVES: 
[OKTA-XXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXX)

#### Primary Reviewer(s):
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

