### PR TITLE
Fix CustomTabsServiceConnection leak

### DIFF
--- a/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
+++ b/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
@@ -16,7 +16,6 @@
 package com.okta.oidc;
 
 import android.app.Activity;
-import android.content.ComponentName;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
@@ -263,7 +262,7 @@ public class OktaAuthenticationActivity extends Activity implements ServiceConne
 
     /**
      * Called when the service is connected.
-     * @param browserPackage
+     * @param browserPackage browser package
      * @param customTabsClient a CustomTabsClient
      */
     public void onServiceConnected(String browserPackage, CustomTabsClient customTabsClient) {

--- a/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
+++ b/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
@@ -52,7 +52,7 @@ import static com.okta.oidc.net.ConnectionParameters.X_OKTA_USER_AGENT;
  * @see "Authorization Code with PKCE flow <https://developer.okta.com/authentication-guide/auth-overview/#authorization-code-with-pkce-flow>"
  * @see "Implementing the Authorization Code with PKCE flow <https://developer.okta.com/authentication-guide/implementing-authentication/auth-code-pkce/>"
  */
-public class OktaAuthenticationActivity extends Activity {
+public class OktaAuthenticationActivity extends Activity implements ServiceConnectionCallback {
     private static final String TAG = OktaAuthenticationActivity.class.getSimpleName();
     /**
      * The Extra auth started.
@@ -253,29 +253,34 @@ public class OktaAuthenticationActivity extends Activity {
      * @param browserPackage the browser package
      */
     @VisibleForTesting
-    protected void bindServiceAndStart(@NonNull final String browserPackage) {
+    protected void bindServiceAndStart(@NonNull String browserPackage) {
         if (mConnection != null) {
             return;
         }
-        mConnection = new CustomTabsServiceConnection() {
-            @Override
-            public void onServiceDisconnected(ComponentName componentName) {
-                mAuthStarted = false;
-            }
-
-            @Override
-            public void onCustomTabsServiceConnected(ComponentName componentName,
-                                                     CustomTabsClient customTabsClient) {
-                CustomTabsSession session = null;
-                if (customTabsClient != null) {
-                    customTabsClient.warmup(0);
-                    session = createSession(customTabsClient);
-                }
-                mAuthStarted = true;
-                startActivity(createBrowserIntent(browserPackage, session));
-            }
-        };
+        mConnection = new ServiceConnection(browserPackage, this);
         CustomTabsClient.bindCustomTabsService(this, browserPackage, mConnection);
+    }
+
+    /**
+     * Called when the service is connected.
+     * @param browserPackage
+     * @param customTabsClient a CustomTabsClient
+     */
+    public void onServiceConnected(String browserPackage, CustomTabsClient customTabsClient) {
+        CustomTabsSession session = null;
+        if (customTabsClient != null) {
+            customTabsClient.warmup(0);
+            session = createSession(customTabsClient);
+        }
+        mAuthStarted = true;
+        startActivity(createBrowserIntent(browserPackage, session));
+    }
+
+    /**
+     * Called when the service is disconnected.
+     */
+    public void onServiceDisconnected() {
+        mAuthStarted = true;
     }
 
     private void sendResult(int rc, Intent intent) {

--- a/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
+++ b/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
@@ -280,7 +280,7 @@ public class OktaAuthenticationActivity extends Activity implements ServiceConne
      * Called when the service is disconnected.
      */
     public void onServiceDisconnected() {
-        mAuthStarted = true;
+        mAuthStarted = false;
     }
 
     private void sendResult(int rc, Intent intent) {

--- a/library/src/main/java/com/okta/oidc/ServiceConnection.java
+++ b/library/src/main/java/com/okta/oidc/ServiceConnection.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License,
+ * Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.okta.oidc;
+
+import android.content.ComponentName;
+
+import java.lang.ref.WeakReference;
+
+import androidx.browser.customtabs.CustomTabsClient;
+import androidx.browser.customtabs.CustomTabsServiceConnection;
+
+/**
+ * Implementation for the CustomTabsServiceConnection that avoids leaking the
+ * ServiceConnectionCallback
+ */
+/*package*/ final class ServiceConnection extends CustomTabsServiceConnection {
+    private final String mBrowserPackage;
+    // A weak reference to the ServiceConnectionCallback to avoid leaking it.
+    private WeakReference<ServiceConnectionCallback> mConnectionCallbackWr;
+
+    public ServiceConnection(String browserPackage,
+                             ServiceConnectionCallback connectionCallback) {
+        mBrowserPackage = browserPackage;
+        mConnectionCallbackWr = new WeakReference<>(connectionCallback);
+    }
+
+    @Override
+    public void onCustomTabsServiceConnected(ComponentName name, CustomTabsClient client) {
+        ServiceConnectionCallback connectionCallback = mConnectionCallbackWr.get();
+        if (connectionCallback != null) {
+            connectionCallback.onServiceConnected(mBrowserPackage, client);
+        }
+    }
+
+    @Override
+    public void onServiceDisconnected(ComponentName name) {
+        ServiceConnectionCallback connectionCallback = mConnectionCallbackWr.get();
+        if (connectionCallback != null) {
+            connectionCallback.onServiceDisconnected();
+        }
+    }
+}

--- a/library/src/main/java/com/okta/oidc/ServiceConnection.java
+++ b/library/src/main/java/com/okta/oidc/ServiceConnection.java
@@ -17,21 +17,21 @@ package com.okta.oidc;
 
 import android.content.ComponentName;
 
-import java.lang.ref.WeakReference;
-
 import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsServiceConnection;
 
+import java.lang.ref.WeakReference;
+
 /**
  * Implementation for the CustomTabsServiceConnection that avoids leaking the
- * ServiceConnectionCallback
+ * ServiceConnectionCallback.
  */
 /*package*/ final class ServiceConnection extends CustomTabsServiceConnection {
     private final String mBrowserPackage;
     // A weak reference to the ServiceConnectionCallback to avoid leaking it.
     private WeakReference<ServiceConnectionCallback> mConnectionCallbackWr;
 
-    public ServiceConnection(String browserPackage,
+    ServiceConnection(String browserPackage,
                              ServiceConnectionCallback connectionCallback) {
         mBrowserPackage = browserPackage;
         mConnectionCallbackWr = new WeakReference<>(connectionCallback);

--- a/library/src/main/java/com/okta/oidc/ServiceConnectionCallback.java
+++ b/library/src/main/java/com/okta/oidc/ServiceConnectionCallback.java
@@ -23,7 +23,7 @@ import androidx.browser.customtabs.CustomTabsClient;
 /*package*/ interface ServiceConnectionCallback {
     /**
      * Called when the service is connected.
-     * @param browserPackage
+     * @param browserPackage browser package
      * @param client a CustomTabsClient
      */
     void onServiceConnected(String browserPackage,

--- a/library/src/main/java/com/okta/oidc/ServiceConnectionCallback.java
+++ b/library/src/main/java/com/okta/oidc/ServiceConnectionCallback.java
@@ -12,19 +12,25 @@
  * See the License for the specific language governing permissions and limitations under the
  * License.
  */
+
 package com.okta.oidc;
 
-import androidx.annotation.NonNull;
+import androidx.browser.customtabs.CustomTabsClient;
 
-import static com.okta.oidc.util.JsonStrings.CHROME;
+/**
+ * Callback for events when connecting and disconnecting from Custom Tabs Service.
+ */
+/*package*/ interface ServiceConnectionCallback {
+    /**
+     * Called when the service is connected.
+     * @param browserPackage
+     * @param client a CustomTabsClient
+     */
+    void onServiceConnected(String browserPackage,
+                            CustomTabsClient client);
 
-public class OktaAuthenticationActivityMock extends OktaAuthenticationActivity {
-
-    protected String getBrowser() {
-        return CHROME;
-    }
-
-    protected void bindServiceAndStart(@NonNull final String browserPackage) {
-        onServiceConnected(browserPackage, null);
-    }
+    /**
+     * Called when the service is disconnected.
+     */
+    void onServiceDisconnected();
 }


### PR DESCRIPTION
Custom Tabs service may hold onto our connection (even though disconnected)
until GC.

This will prevent a leak of OktaAuthenticationActivity (thanks Leak Canary!)

#### Description:

#### Testing details:
- [x]  Verified basic functionality of change
- [ ]  Added tests 

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes

##### RESOLVES: 
https://github.com/okta/okta-oidc-android/issues/154

#### Primary Reviewer(s):
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

