### PR TITLE
HttpResponse: Throw HttpStatusCodeException when unexpected status code is encountered

### DIFF
--- a/library/src/main/java/com/okta/oidc/net/HttpResponse.java
+++ b/library/src/main/java/com/okta/oidc/net/HttpResponse.java
@@ -109,8 +109,7 @@ public final class HttpResponse {
     public JSONObject asJson() throws IOException, JSONException {
         if (mStatusCode < HttpURLConnection.HTTP_OK ||
                 mStatusCode >= HttpURLConnection.HTTP_MULT_CHOICE) {
-            throw new IOException("Invalid status code " + mStatusCode +
-                    " " + mHttpClient.getResponseMessage());
+            throw new HttpStatusCodeException(mStatusCode, mHttpClient.getResponseMessage());
         }
         InputStream is = getContent();
         if (is == null) {

--- a/library/src/main/java/com/okta/oidc/net/HttpStatusCodeException.java
+++ b/library/src/main/java/com/okta/oidc/net/HttpStatusCodeException.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License,
+ * Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.okta.oidc.net;
+
+import androidx.annotation.NonNull;
+
+import java.io.IOException;
+
+/**
+ * Thrown when an unexpected status code is encountered during
+ * serialization of an HTTP response.
+ */
+public class HttpStatusCodeException extends IOException {
+    private final int statusCode;
+    private final String statusMessage;
+
+    /**
+     * Instantiates an HttpStatusCodeException with the given HTTP status code, and
+     * status message.
+     *
+     * @param statusCode The HTTP status code that was not expected
+     * @param statusMessage The message contained in the response HTTP message
+     */
+    public HttpStatusCodeException(int statusCode, @NonNull String statusMessage) {
+        super("Invalid status code " + statusCode +
+                " " + statusMessage);
+        this.statusCode = statusCode;
+        this.statusMessage = statusMessage;
+    }
+
+    /**
+     * Returns the HTTP status code that was unexpected when
+     * this exception occurred.
+     * @return The HTTP status code
+     */
+    public int getStatusCode() {
+        return this.statusCode;
+    }
+
+    /**
+     * Returns the HTTP status message contained in the HTTP response
+     * when this exception occurred.
+     * @return The HTTP status message
+     */
+    @NonNull
+    public String getStatusMessage() {
+        return this.statusMessage;
+    }
+}

--- a/library/src/test/java/com/okta/oidc/net/HttpResponseTest.java
+++ b/library/src/test/java/com/okta/oidc/net/HttpResponseTest.java
@@ -58,6 +58,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 27)
@@ -195,6 +196,7 @@ public class HttpResponseTest {
         int contentLength = response.getContentLength();
         int status = response.getStatusCode();
 
+        assertThrows(HttpStatusCodeException.class, response::asJson);
         assertEquals(HTTP_NOT_FOUND, status);
         assertNotNull(headers);
         assertEquals(contentLength, CONFIGURATION_NOT_FOUND.length());


### PR DESCRIPTION
Prerequisite to: OKTA-282915

#### Description:
Adds a new `HttpStatusCodeException` that subclasses `IOException` that is thrown when an unexpected status code is encountered on parsing the response as JSON, in place of a plain IOException.

This change is transparent to existing consumers that are unaware of `HttpStatusCodeException`. The underlying exception message remains the same as before.

#### Testing details:
- [x]  Verified basic functionality of change
- [x]  Added tests 

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes

##### RESOLVES: 
[OKTA-282915](https://oktainc.atlassian.net/browse/OKTA-282915)

#### Primary Reviewer(s):
@FeiChen-okta 
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

