### PR TITLE
Add no history flag to custom tab intent

### DIFF
--- a/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
+++ b/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import static android.content.Intent.FLAG_ACTIVITY_NO_HISTORY;
 import static com.okta.oidc.net.ConnectionParameters.USER_AGENT_HEADER;
 import static com.okta.oidc.net.ConnectionParameters.X_OKTA_USER_AGENT;
 
@@ -227,6 +228,7 @@ public class OktaAuthenticationActivity extends Activity implements ServiceConne
         CustomTabsIntent tabsIntent = intentBuilder.build();
         tabsIntent.intent.setPackage(packageName);
         tabsIntent.intent.setData(mAuthUri);
+        tabsIntent.intent.setFlags(FLAG_ACTIVITY_NO_HISTORY);
         Bundle headers = new Bundle();
         headers.putString(X_OKTA_USER_AGENT, USER_AGENT_HEADER);
         tabsIntent.intent.putExtra(Browser.EXTRA_HEADERS, headers);


### PR DESCRIPTION
#### Description:
Switching to singleInstance to fix taskAffinity leaves
CCT in the backstack. Fix this by setting no history.


