### PR TITLE
Remove duplicate creation of default HttpClient

### DIFF
--- a/library/src/main/java/com/okta/oidc/OktaBuilder.java
+++ b/library/src/main/java/com/okta/oidc/OktaBuilder.java
@@ -191,9 +191,6 @@ public abstract class OktaBuilder<A, T extends OktaBuilder<A, T>> {
         if (mEncryptionManager == null) {
             mEncryptionManager = new DefaultEncryptionManager(mContext);
         }
-        if (mClient == null) {
-            mClient = new HttpClientImpl();
-        }
         if (mStorage == null) {
             mStorage = new SharedPreferenceStorage(mContext);
         }


### PR DESCRIPTION
#### Description:

obvious fix

code to initialize the default `HttpClientImpl()` was included twice in the `createAuthClient()` method.

#### Testing details:
- [ ]  Verified basic functionality of change
- [ ]  Added tests 

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes

#### Primary Reviewer(s):
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

