### PR TITLE
Add internet permission to library manifest.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.okta.oidc.example">
 
-    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         </intent>
     </queries>
 
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <application>
         <activity


### PR DESCRIPTION
#### Description:
I recently created a new project using this SDK. I found it surprising that I had to add internet permission to the manifest given that this SDK was using internet for getting the `.well-known/openid-configuration` endpoint.

#### Testing details:
- [x]  Verified basic functionality of change
- [ ]  Added tests 

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes

##### RESOLVES: 
[OKTA-XXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXX)

#### Primary Reviewer(s):
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

