### PR TITLE
Fix for ActivityNotFoundException (closes #166)

### DIFF
--- a/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
+++ b/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
@@ -282,7 +282,7 @@ public class OktaAuthenticationActivity extends Activity implements ServiceConne
         try {
             startActivity(createBrowserIntent(browserPackage, session));
         } catch (ActivityNotFoundException e) {
-            sendResult(RESULT_OK, getIntent().putExtra(EXTRA_EXCEPTION,
+            sendResult(RESULT_CANCELED, getIntent().putExtra(EXTRA_EXCEPTION,
                     AuthorizationException.GeneralErrors.NO_BROWSER_FOUND.toJsonString()));
         }
     }


### PR DESCRIPTION
#### Description:

We have a lot of crashes with this exception in production. I'm not sure about a root cause, but it's better to display a meaningful message to the user (browser not found) than to crash the app.

