### PR TITLE
Fix for a crash in logout (closes #263)

### DIFF
--- a/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
+++ b/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
@@ -282,7 +282,7 @@ public class OktaAuthenticationActivity extends Activity implements ServiceConne
         try {
             startActivity(createBrowserIntent(browserPackage, session));
         } catch (ActivityNotFoundException e) {
-            sendResult(RESULT_OK, getIntent().putExtra(EXTRA_EXCEPTION,
+            sendResult(RESULT_CANCELED, getIntent().putExtra(EXTRA_EXCEPTION,
                     AuthorizationException.GeneralErrors.NO_BROWSER_FOUND.toJsonString()));
         }
     }

--- a/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
+++ b/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
@@ -16,6 +16,7 @@
 package com.okta.oidc;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
@@ -278,7 +279,12 @@ public class OktaAuthenticationActivity extends Activity implements ServiceConne
             session = createSession(customTabsClient);
         }
         mAuthStarted = true;
-        startActivity(createBrowserIntent(browserPackage, session));
+        try {
+            startActivity(createBrowserIntent(browserPackage, session));
+        } catch (ActivityNotFoundException e) {
+            sendResult(RESULT_OK, getIntent().putExtra(EXTRA_EXCEPTION,
+                    AuthorizationException.GeneralErrors.NO_BROWSER_FOUND.toJsonString()));
+        }
     }
 
     /**

--- a/library/src/main/java/com/okta/oidc/OktaResultFragment.java
+++ b/library/src/main/java/com/okta/oidc/OktaResultFragment.java
@@ -22,6 +22,7 @@ import android.net.Uri;
 import androidx.annotation.RestrictTo;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
 
 import com.okta.oidc.net.request.web.WebRequest;
 
@@ -58,10 +59,12 @@ public class OktaResultFragment extends Fragment {
         OktaResultFragment fragment = new OktaResultFragment();
         fragment.logoutIntent = createAuthIntent(activity, request.toUri(), customTabOptions,
                 browsers);
-        activity.getSupportFragmentManager()
-                .beginTransaction()
-                .add(fragment, AUTHENTICATION_REQUEST)
-                .commit();
+        FragmentManager fragmentManager = activity.getSupportFragmentManager();
+        if (!fragmentManager.isDestroyed()) {
+            fragmentManager.beginTransaction()
+                           .add(fragment, AUTHENTICATION_REQUEST)
+                           .commit();
+        }
     }
 
     @Override

--- a/library/src/test/java/com/okta/oidc/OktaResultFragmentTest.java
+++ b/library/src/test/java/com/okta/oidc/OktaResultFragmentTest.java
@@ -15,12 +15,22 @@
 
 package com.okta.oidc;
 
+import static android.app.Activity.RESULT_OK;
+import static com.okta.oidc.AuthenticationResultHandler.handler;
+import static com.okta.oidc.OktaAuthenticationActivity.EXTRA_EXCEPTION;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.okta.oidc.net.request.ProviderConfiguration;
@@ -37,11 +47,6 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-
-import static android.app.Activity.RESULT_OK;
-import static com.okta.oidc.AuthenticationResultHandler.handler;
-import static com.okta.oidc.OktaAuthenticationActivity.EXTRA_EXCEPTION;
-import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 27)
@@ -118,6 +123,29 @@ public class OktaResultFragmentTest {
 
     @Test
     public void handleAuthorizationResponseLogoutSuccess() throws AuthorizationException {
+        OktaResultFragment.addLogoutFragment(TestValues.getAuthorizeRequest(mConfig, null), mCustomTabOptions, mActivity, new String[]{});
+        handler().setAuthenticationListener(listener);
+        Intent intent = new Intent();
+        intent.setData(Uri.parse("com.okta.test:/logout?state=" + CUSTOM_STATE));
+
+        getOktaResultFragment(mActivity).onActivityResult(OktaResultFragment.REQUEST_CODE_SIGN_OUT, RESULT_OK, intent);
+
+        ArgumentCaptor<AuthenticationResultHandler.StateResult> resultCapture = ArgumentCaptor.forClass(AuthenticationResultHandler.StateResult.class);
+        ArgumentCaptor<AuthenticationResultHandler.ResultType> resultTypeCapture = ArgumentCaptor.forClass(AuthenticationResultHandler.ResultType.class);
+        verify(listener).postResult(resultCapture.capture(), resultTypeCapture.capture());
+
+        assert (getOktaResultFragment(mActivity) == null);
+        assert (resultCapture.getValue().getStatus() == AuthenticationResultHandler.Status.LOGGED_OUT);
+        assert (resultTypeCapture.getValue() == AuthenticationResultHandler.ResultType.SIGN_OUT);
+    }
+
+    @Test
+    public void handleAuthorizationResponseLogoutSuccessWhenFragmentManagerIsDestroyed() throws AuthorizationException {
+        FragmentManager mockFragmentManager = mock(FragmentManager.class);
+        FragmentActivity spyActivity = spy(mActivity);
+        when(spyActivity.getSupportFragmentManager()).thenReturn(mockFragmentManager);
+        when(mockFragmentManager.isDestroyed()).thenReturn(true);
+
         OktaResultFragment.addLogoutFragment(TestValues.getAuthorizeRequest(mConfig, null), mCustomTabOptions, mActivity, new String[]{});
         handler().setAuthenticationListener(listener);
         Intent intent = new Intent();


### PR DESCRIPTION
We see crashes in logout in our production app. Here is the stacktrace:

```
Fatal Exception: java.lang.IllegalStateException
FragmentManager has been destroyed
androidx.fragment.app.FragmentManager.enqueueAction (FragmentManager.java:1542)

androidx.fragment.app.BackStackRecord.commit (BackStackRecord.java:306)
com.okta.oidc.OktaResultFragment.addLogoutFragment (OktaResultFragment.java:64)
com.okta.oidc.clients.web.SyncWebAuthClientImpl.lambda$startSignOut$4 (SyncWebAuthClientImpl.java:321)
com.okta.oidc.clients.web.SyncWebAuthClientImpl.$r8$lambda$9xGAYUir3zQW6WeNxzc89L77keM (SyncWebAuthClientImpl.java)
com.okta.oidc.clients.web.SyncWebAuthClientImpl$$InternalSyntheticLambda$0$d787f1d4a5cbac304e1d1e8dca806be8b9084ceb4a03a44ad24a9ec426c49b62$0.run (SyncWebAuthClientImpl.java:6)
```

The app crashes, because `FragmentManager` is destroyed, but the SDK is trying to commit a `Fragment` transaction.

I'm not sure about the root cause, but the fix is a simple check if `FragmentManager` is destroyed. It should not crash in this case and normal functionality should not be affected.

Closes this issue: https://github.com/okta/okta-oidc-android/issues/263