### PR TITLE
Validate TokenResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,6 @@ android {
 
 For more details on Java 8 support for your Android projects, refer to the [Android developer documentations](#https://developer.android.com/studio/write/java8-support)
 
-### Proguard
-
-The SDK uses GSON for serialization. As a result, proguard/R8 obfuscation can result in incorrect behavior or crashes. To avoid issues with Proguard/R8, add the following rules to proguard-rules.pro:
-
-```
--keep class com.okta.oidc.** { *; }
-```
-
 ### Sample app
 
 A sample is contained within this repository. For more information on how to

--- a/library/src/main/java/com/okta/oidc/net/response/TokenResponse.java
+++ b/library/src/main/java/com/okta/oidc/net/response/TokenResponse.java
@@ -15,9 +15,12 @@
 
 package com.okta.oidc.net.response;
 
+import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
+import androidx.annotation.VisibleForTesting;
 
 import com.google.gson.Gson;
 import com.okta.oidc.storage.Persistable;
@@ -36,6 +39,13 @@ public class TokenResponse implements Persistable {
     private String refresh_token;
     private String id_token;
     private long expiresAt = -1;
+
+    @VisibleForTesting
+    public static final String MISSING_ACCESS_TOKEN_ERROR = "access_token is missing";
+    @VisibleForTesting
+    public static final String MISSING_TOKEN_TYPE_ERROR = "token_type is missing";
+    @VisibleForTesting
+    public static final String MISSING_EXPIRES_IN_ERROR = "expires_in is missing";
 
     @NonNull
     public String getAccessToken() {
@@ -81,6 +91,18 @@ public class TokenResponse implements Persistable {
             expiresAt += Integer.parseInt(expires_in) * THOUSAND;
         }
         return expiresAt;
+    }
+
+    public void validate() throws IllegalArgumentException {
+        if (TextUtils.isEmpty(access_token)) {
+            throw new IllegalArgumentException(MISSING_ACCESS_TOKEN_ERROR);
+        }
+        if (TextUtils.isEmpty(token_type)) {
+            throw new IllegalArgumentException(MISSING_TOKEN_TYPE_ERROR);
+        }
+        if (TextUtils.isEmpty(expires_in)) {
+            throw new IllegalArgumentException(MISSING_EXPIRES_IN_ERROR);
+        }
     }
 
     public static final Persistable.Restore<TokenResponse> RESTORE =

--- a/library/src/test/java/com/okta/oidc/net/request/TokenRequestTest.java
+++ b/library/src/test/java/com/okta/oidc/net/request/TokenRequestTest.java
@@ -123,4 +123,13 @@ public class TokenRequestTest {
         TokenResponse response = mRequest.executeRequest(mHttpClient);
         assertNull(response);
     }
+
+    @Test
+    public void executeRequestFailedValidation() throws AuthorizationException {
+        mExpectedEx.expect(AuthorizationException.class);
+        String jws = TestValues.getJwt(mEndPoint.getUrl(), CUSTOM_NONCE, mConfig.getClientId());
+        mEndPoint.enqueueTokenWithMissingRequiredParams(jws);
+        TokenResponse response = mRequest.executeRequest(mHttpClient);
+        assertNull(response);
+    }
 }

--- a/library/src/test/java/com/okta/oidc/net/response/TokenResponseTest.java
+++ b/library/src/test/java/com/okta/oidc/net/response/TokenResponseTest.java
@@ -27,6 +27,9 @@ import java.util.Arrays;
 
 import static com.okta.oidc.net.response.TokenResponse.RESTORE;
 import static com.okta.oidc.util.JsonStrings.TOKEN_RESPONSE;
+import static com.okta.oidc.util.JsonStrings.TOKEN_RESPONSE_WITH_MISSING_ACCESS_TOKEN;
+import static com.okta.oidc.util.JsonStrings.TOKEN_RESPONSE_WITH_MISSING_EXPIRES_IN;
+import static com.okta.oidc.util.JsonStrings.TOKEN_RESPONSE_WITH_MISSING_TOKEN_TYPE;
 import static com.okta.oidc.util.TestValues.ACCESS_TOKEN;
 import static com.okta.oidc.util.TestValues.EXPIRES_IN;
 import static com.okta.oidc.util.TestValues.ID_TOKEN;
@@ -34,6 +37,7 @@ import static com.okta.oidc.util.TestValues.REFRESH_TOKEN;
 import static com.okta.oidc.util.TestValues.SCOPES;
 import static com.okta.oidc.util.TestValues.TYPE_BEARER;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 27)
@@ -79,6 +83,32 @@ public class TokenResponseTest {
     @Test
     public void getKey() {
         assertEquals(mToken.getKey(), RESTORE.getKey());
+    }
+
+    @Test
+    public void validatePasses() {
+        mToken.validate();
+    }
+
+    @Test
+    public void validateThrowsExceptionWhenAccessTokenIsMissing() {
+        mToken = RESTORE.restore(TOKEN_RESPONSE_WITH_MISSING_ACCESS_TOKEN);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, mToken::validate);
+        assertEquals(TokenResponse.MISSING_ACCESS_TOKEN_ERROR, exception.getMessage());
+    }
+
+    @Test
+    public void validateThrowsExceptionWhenTokenTypeIsMissing() {
+        mToken = RESTORE.restore(TOKEN_RESPONSE_WITH_MISSING_TOKEN_TYPE);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, mToken::validate);
+        assertEquals(TokenResponse.MISSING_TOKEN_TYPE_ERROR, exception.getMessage());
+    }
+
+    @Test
+    public void validateThrowsExceptionWhenExpiresInIsMissing() {
+        mToken = RESTORE.restore(TOKEN_RESPONSE_WITH_MISSING_EXPIRES_IN);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, mToken::validate);
+        assertEquals(TokenResponse.MISSING_EXPIRES_IN_ERROR, exception.getMessage());
     }
 
     @Test

--- a/library/src/test/java/com/okta/oidc/util/JsonStrings.java
+++ b/library/src/test/java/com/okta/oidc/util/JsonStrings.java
@@ -58,6 +58,12 @@ public interface JsonStrings {
             "    \"id_token\" : \"%s\"" +
             "}";
 
+    String TOKEN_MISSING_PARAMS = "{\n" +
+            "    \"scope\"      : \"openid email profile\",\n" +
+            "    \"refresh_token\" : \"a9VpZDRCeFh3Nkk2VdY\",\n" +
+            "    \"id_token\" : \"%s\"" +
+            "}";
+
     String PROVIDER_CONFIG_OAUTH2 = "{\n" +
             "    \"issuer\": \"https://dev-486177.oktapreview.com/oauth2/default/\",\n" +
             "    \"authorization_endpoint\": \"https://dev-486177.oktapreview.com/oauth2/default/v1/authorize\",\n" +
@@ -236,6 +242,21 @@ public interface JsonStrings {
             "\"ACCESS_TOKEN\",\n\"token_type\" : " +
             "\"Bearer\",\n \"expires_in\" : 3600,\n " +
             "\"scope\" : \"openid profile offline_access\",\n " +
+            "\"refresh_token\" : \"REFRESH_TOKEN\",\n\"id_token\" : \"ID_TOKEN\"\n}";
+
+    String TOKEN_RESPONSE_WITH_MISSING_ACCESS_TOKEN = "{ \"token_type\" : " +
+            "\"Bearer\",\n \"expires_in\" : 3600,\n " +
+            "\"scope\" : \"openid profile offline_access\",\n " +
+            "\"refresh_token\" : \"REFRESH_TOKEN\",\n\"id_token\" : \"ID_TOKEN\"\n}";
+
+    String TOKEN_RESPONSE_WITH_MISSING_TOKEN_TYPE = "{ \"access_token\" : " +
+            "\"ACCESS_TOKEN\",\n \"expires_in\" : 3600,\n " +
+            "\"scope\" : \"openid profile offline_access\",\n " +
+            "\"refresh_token\" : \"REFRESH_TOKEN\",\n\"id_token\" : \"ID_TOKEN\"\n}";
+
+    String TOKEN_RESPONSE_WITH_MISSING_EXPIRES_IN = "{ \"access_token\" : " +
+            "\"ACCESS_TOKEN\",\n\"token_type\" : " +
+            "\"Bearer\",\n \"scope\" : \"openid profile offline_access\",\n " +
             "\"refresh_token\" : \"REFRESH_TOKEN\",\n\"id_token\" : \"ID_TOKEN\"\n}";
 
     String INVALID_CLIENT = "{\n" +

--- a/library/src/test/java/com/okta/oidc/util/MockEndPoint.java
+++ b/library/src/test/java/com/okta/oidc/util/MockEndPoint.java
@@ -48,6 +48,7 @@ import static com.okta.oidc.util.JsonStrings.INTROSPECT_RESPONSE;
 import static com.okta.oidc.util.JsonStrings.INVALID_CLIENT;
 import static com.okta.oidc.util.JsonStrings.PROVIDER_CONFIG;
 import static com.okta.oidc.util.JsonStrings.PROVIDER_CONFIG_OAUTH2;
+import static com.okta.oidc.util.JsonStrings.TOKEN_MISSING_PARAMS;
 import static com.okta.oidc.util.JsonStrings.TOKEN_SUCCESS;
 import static com.okta.oidc.util.JsonStrings.UNAUTHORIZED_INVALID_TOKEN;
 import static com.okta.oidc.util.JsonStrings.USER_PROFILE;
@@ -133,6 +134,10 @@ public class MockEndPoint {
 
     public void enqueueTokenSuccess(String idToken) {
         mServer.enqueue(jsonResponse(HTTP_OK, String.format(TOKEN_SUCCESS, idToken)));
+    }
+
+    public void enqueueTokenWithMissingRequiredParams(String idToken) {
+        mServer.enqueue(jsonResponse(HTTP_OK, String.format(TOKEN_MISSING_PARAMS, idToken)));
     }
 
     public void enqueueNativeRequestSuccess(String state, int delaySeconds) {


### PR DESCRIPTION
#### Description:
This PR validates TokenResponse for required parameters before returning the TokenResponse. Otherwise, an AuthorizationException is thrown. access_token, token_type, and expires_in are all required parameters in okta-mobile-kotlin, and so those are the parameters being validated.

Also, reverted an earlier README update which was redundant due to existing [proguard-rules.pro](https://github.com/okta/okta-oidc-android/tree/master/library/proguard-rules.pro) in the SDK.

#### Testing details:
- [ ]  Verified basic functionality of change
- [ ]  Added tests 

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes

##### RESOLVES: 
[OKTA-XXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXX)

#### Primary Reviewer(s):
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

