### PR TITLE
Use browser querying logic from okta-mobile-kotlin

### DIFF
--- a/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
+++ b/library/src/main/java/com/okta/oidc/OktaAuthenticationActivity.java
@@ -180,16 +180,13 @@ public class OktaAuthenticationActivity extends Activity implements ServiceConne
     @VisibleForTesting
     protected String getBrowser() {
         PackageManager pm = getPackageManager();
-        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.example.com"));
-        List<ResolveInfo> resolveInfoList = pm.queryIntentActivities(browserIntent, mMatchFlag);
+        Intent serviceIntent = new Intent();
+        serviceIntent.setAction(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION);
+        List<ResolveInfo> resolveInfoList = pm.queryIntentServices(serviceIntent, mMatchFlag);
         List<String> customTabsBrowsers = new ArrayList<>();
+
         for (ResolveInfo info : resolveInfoList) {
-            Intent serviceIntent = new Intent();
-            serviceIntent.setAction(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION);
-            serviceIntent.setPackage(info.activityInfo.packageName);
-            if (pm.resolveService(serviceIntent, 0) != null) {
-                customTabsBrowsers.add(info.activityInfo.packageName);
-            }
+            customTabsBrowsers.add(info.serviceInfo.packageName);
         }
         for (String browser : mSupportedBrowsers) {
             if (customTabsBrowsers.contains(browser)) {


### PR DESCRIPTION
#### Description:
Copied over the browser querying logic from okta-mobile-kotlin, which avoids having to use matchAll flag when the default system browser doesn't support chrome custom tabs.

#### Testing details:
- [ ]  Verified basic functionality of change
- [ ]  Added tests 

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes

##### RESOLVES: 
[OKTA-XXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXX)

#### Primary Reviewer(s):
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

