### PR TITLE
Update libraries to address CVEs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     // Assertions
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.ext:truth:1.5.0'
-    androidTestImplementation 'com.google.truth:truth:1.1.5'
+    androidTestImplementation "com.google.truth:truth:${rootProject.truthVersion}"
 
     // AndroidJUnitRunner and JUnit Rules
     androidTestImplementation 'androidx.test:runner:1.5.2'

--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ ext {
     junitVersion = '4.13.2'
     mockitoVersion = "4.6.1"
     robolectricVersion = '4.11'
+    truthVersion = '1.1.5'
     okhttpVersion = '4.11.0'
     okioVersion = '3.4.0'
     jsonWebTokenVersion = '0.11.2'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${rootProject.mockitoVersion}"
     testImplementation "org.mockito:mockito-inline:${rootProject.mockitoVersion}"
     testImplementation "org.robolectric:robolectric:${rootProject.robolectricVersion}"
+    testImplementation "com.google.truth:truth:${rootProject.truthVersion}"
     testImplementation "com.squareup.okhttp3:mockwebserver:${rootProject.okhttpVersion}"
     testImplementation "com.squareup.okhttp3:okhttp:${rootProject.okhttpVersion}"
     testImplementation "com.squareup.okio:okio:${rootProject.okioVersion}"


### PR DESCRIPTION
#### Description:
This PR adds `com.google.truth` to okta-oidc-android library's build.gradle. Doing this also updates guava version. I have added the dependency graph for before and after this PR. Observe that guava-31.1-jre gets overriden by guava-32.0.1-android in dependencies-after-pr.txt.

[dependencies-before-pr.txt](https://github.com/okta/okta-oidc-android/files/13369434/dependencies-before-pr.txt)
[dependencies-after-pr.txt](https://github.com/okta/okta-oidc-android/files/13369436/dependencies-after-pr.txt)


#### Testing details:
- [ ]  Verified basic functionality of change
- [ ]  Added tests 

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes

##### RESOLVES: 
[OKTA-XXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXX)

#### Primary Reviewer(s):
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

