### PR TITLE
Clean the state store file when we have an error to avoid recurring

### DIFF
--- a/library/src/main/java/com/okta/oidc/clients/AuthAPI.java
+++ b/library/src/main/java/com/okta/oidc/clients/AuthAPI.java
@@ -158,6 +158,12 @@ public class AuthAPI {
                 .createRequest();
     }
 
+    protected void clear() {
+        mOktaState.delete(ProviderConfiguration.RESTORE.getKey());
+        mOktaState.delete(TokenResponse.RESTORE.getKey());
+        mOktaState.delete(WebRequest.RESTORE.getKey());
+    }
+
     protected void resetCurrentState() {
         mCancel.set(false);
         mOktaState.setCurrentState(IDLE);

--- a/library/src/main/java/com/okta/oidc/clients/AuthAPI.java
+++ b/library/src/main/java/com/okta/oidc/clients/AuthAPI.java
@@ -36,6 +36,7 @@ import com.okta.oidc.net.request.ProviderConfiguration;
 import com.okta.oidc.net.request.TokenRequest;
 import com.okta.oidc.net.request.web.AuthorizeRequest;
 import com.okta.oidc.net.request.web.WebRequest;
+import com.okta.oidc.net.response.TokenResponse;
 import com.okta.oidc.net.response.web.AuthorizeResponse;
 import com.okta.oidc.net.response.web.WebResponse;
 import com.okta.oidc.storage.OktaRepository;

--- a/library/src/main/java/com/okta/oidc/clients/SyncAuthClientImpl.java
+++ b/library/src/main/java/com/okta/oidc/clients/SyncAuthClientImpl.java
@@ -108,10 +108,13 @@ class SyncAuthClientImpl extends AuthAPI implements SyncAuthClient {
             mOktaState.save(tokenResponse);
             return Result.success();
         } catch (AuthorizationException e) {
+            clear();
             return Result.error(e);
         } catch (IOException e) {
+            clear();
             return Result.cancel();
         } catch (Exception e) {
+            clear();
             return Result.error(new AuthorizationException(OTHER.code, e.getMessage(), e));
         } finally {
             resetCurrentState();


### PR DESCRIPTION
#### Description:

Sometimes we have some errors when we try to execute certain calls to Okta and when the information's state at the storage becomes corrupted it's never cleaned and the error keeps recurring and makes the login completely impossible again.

Some stack errors:

Clean the state store file when we have an error to avoid recurring.